### PR TITLE
Delay cache file creation

### DIFF
--- a/src/bygg/cache.py
+++ b/src/bygg/cache.py
@@ -26,9 +26,9 @@ class Cache:
     def __init__(self, db_file: Path = DEFAULT_DB_FILE):
         self.data = CacheState({})
         self.db_file = db_file
-        make_sure_status_dir_exists()
 
     def load(self):
+        make_sure_status_dir_exists()
         try:
             with open(self.db_file, "rb") as f:
                 self.data = pickle.load(f)


### PR DESCRIPTION
When called with -C/--directory, the cache directory and file would be created in the directory where the process was started and not in the directory where it should be executed.

Delaying the creation of the cache file until the cache is about to be loaded makes it be created after the process has done its chdir.

Closes #1.