### PR TITLE
Trigger test workflow only on push to branches

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,6 +1,7 @@
 name: Run tests
 on:
-  push: {}
+  push:
+    branches: [ "**" ]
   pull_request:
     branches: [ "master" ]
 


### PR DESCRIPTION
The test workflow would otherwise run also when tags were pushed.