### PR TITLE
Run tests only on push, not for pull_requests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,8 +2,6 @@ name: Run tests
 on:
   push:
     branches: [ "**" ]
-  pull_request:
-    branches: [ "master" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Running the tests when commits are pushed should be sufficient, since all pull requests should trigger at least one push event.