### PR TITLE
Clarify scheduler behaviour

### DIFF
--- a/src/bygg/scheduler.py
+++ b/src/bygg/scheduler.py
@@ -169,8 +169,12 @@ class Scheduler:
 
     def get_ready_jobs(self, batch_size: int = 0) -> List[Job]:
         """
-        Create a batch of jobs and put them in the running pool. Returns all ready jobs if
-        batch_size is 0.
+        Create a batch of jobs and put them in the running pool. Returns all ready jobs
+        if batch_size is 0.
+
+        An empty job list may be returned even if there are more jobs left to run if all
+        jobs in the batch were skipped. Job runners should continue polling for more
+        jobs until the scheduler status is "finished".
         """
         if batch_size == 0 or len(self.ready_jobs) < batch_size:
             new_jobs = self.job_graph.get_ready_jobs(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -367,9 +367,10 @@ def test_scheduler_dynamic_dependency_two_runs():
 
     jobs = scheduler.get_ready_jobs()
     assert len(jobs) == 0
+    assert scheduler.run_status() == "running"
 
-    # Asking again triggers the scheduler to realise whether it's done or not.
-    # TODO this behaviour should probably be changeed.
+    # Ask again since the job should have been skipped and the scheduler is still
+    # running:
     job = scheduler.get_ready_jobs()[0]
     assert job
     assert len(scheduler.job_graph) == 1


### PR DESCRIPTION
Clarify that it is valid for the scheduler to return an empty jobs list even if there are no jobs currently running and there are more jobs left to run if all jobs in the current ready list were skipped.

Runners should continue polling for jobs until the scheduler is no longer in "running" state.