### PR TITLE
Make the build setup commands mutually exclusive

### DIFF
--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -259,9 +259,10 @@ List available actions:
         help="Entrypoint actions to operate on.",
     )
     # Commands that operate on the build setup:
-    build_setup_group = parser.add_argument_group(
+    build_setup_wrapper_group = parser.add_argument_group(
         "Commands that operate on the build setup"
-    )
+    )  # add_mutually_exclusive_group doesn't accept a title, so wrap it in a regular group.
+    build_setup_group = build_setup_wrapper_group.add_mutually_exclusive_group()
     build_setup_group.add_argument(
         "-c",
         "--check",


### PR DESCRIPTION
It doesn't make sense to have the user give more than one of the check, clean and list commands at the same time, so tell argparse to make them mutually exclusive.