### PR TITLE
Assert os.cpu_count return value

### DIFF
--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -35,7 +35,9 @@ def get_job_count_limit():
         # https://stackoverflow.com/a/55423170
         return len(os.sched_getaffinity(0))
     except AttributeError:
-        return os.cpu_count()
+        count = os.cpu_count()
+        assert count is not None
+        return count
 
 
 def init_status_listeners():


### PR DESCRIPTION
os.cpu_count returns None if it cannot determine the number of CPUs. Assert that this case doesn't occur so that the get_job_count_limit implementation can be adjusted and/or amended if the assert triggers.