### PR TITLE
Renovate shell tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,21 +99,33 @@ be used for declaring other (static) actions. See
 
 ## Shell tab completions
 
-Bygg has support for Bash and Zsh tab completions of entrypoint actions. The completions will be loaded:
+TL;DR: `bygg --completions`
 
-- from `Byggfile.py` if if `Byggfile.yml` doesn't exist, or there are no environments declared in `Byggfile.yml`.
-- from `Byggfile.yml` -- in this case, no Python files will be loaded to look
-  for entrypoint actions.
+Bygg has support for Bash and Zsh tab completions of arguments and entrypoint
+actions. The completions will be loaded:
 
-### Bygg is installed with pipx or pip
+- from `Byggfile.py` if `Byggfile.yml` doesn't exist, or if there are no
+  environments declared in `Byggfile.yml`.
+- from `Byggfile.yml` if it exists and has environments. In this case, only the
+  entrypoint actions listed in `Byggfile.yml` will be loaded; no Python files
+  will be loaded to look for entrypoint actions since this might require an
+  lengthy (in the context) install of environments.
 
-Add the following lines to `.bashrc` or `.zshrc`:
+To install completions, do:
 
 ```shell
-eval "$($(dirname $(readlink -f $(which bygg)))/register-python-argcomplete bygg)"
+bygg --completions
 ```
 
-### Bygg is installed in its own virtual environment managed by you
+It will output a line that you can then add to `.bashrc` or `.zshrc`.
+
+_Don't forget to open a new shell instance after you've made changes to the
+settings files._
+
+<details>
+<summary>
+Manual steps
+</summary>
 
 Add the following line to `.bashrc` or `.zshrc`:
 
@@ -121,10 +133,10 @@ Add the following line to `.bashrc` or `.zshrc`:
 eval "$(.your_bygg_venv/bin/register-python-argcomplete .your_bygg_venv/bin/bygg)"
 ```
 
-_Don't forget to open a new shell instance after you've made changes to the
-settings files._
+</details>
 
-### Note for Zsh + argcomplete v2 users
+<details>
+<summary>Note for Zsh + argcomplete v2 users</summary>
 
 The recommended setup above uses the argcomplete that is installed with Bygg,
 since this version (starting with v3) has proper support for Zsh so that the
@@ -136,6 +148,8 @@ layer first, and then the Bygg completions:
 autoload -U bashcompinit ; bashcompinit
 eval "$(register-python-argcomplete bygg)"
 ```
+
+</details>
 
 ## Getting a local copy
 

--- a/src/bygg/apply_configuration.py
+++ b/src/bygg/apply_configuration.py
@@ -74,6 +74,27 @@ def should_restart_with(environment: Environment) -> str | None:
     return None
 
 
+def register_actions_from_configuration(
+    configuration: ByggFile, is_restarted_with_env: str | None
+):
+    for action in configuration.actions:
+        if is_restarted_with_env and action.environment != is_restarted_with_env:
+            continue
+
+        shell_command = (
+            create_shell_command(action.shell, action.message) if action.shell else None
+        )
+        Action(
+            action.name,
+            description=action.description,
+            is_entrypoint=bool(action.is_entrypoint),
+            inputs=action.inputs,
+            outputs=action.outputs,
+            dependencies=action.dependencies,
+            command=shell_command,
+        )
+
+
 def apply_configuration(
     configuration: ByggFile,
     environment_name: str | None,
@@ -93,23 +114,7 @@ def apply_configuration(
                 return restart_with
 
     # Now set up the actions for the current environment:
-
-    for action in configuration.actions:
-        if is_restarted_with_env and action.environment != is_restarted_with_env:
-            continue
-
-        shell_command = (
-            create_shell_command(action.shell, action.message) if action.shell else None
-        )
-        Action(
-            action.name,
-            description=action.description,
-            is_entrypoint=bool(action.is_entrypoint),
-            inputs=action.inputs,
-            outputs=action.outputs,
-            dependencies=action.dependencies,
-            command=shell_command,
-        )
+    register_actions_from_configuration(configuration, is_restarted_with_env)
 
     # Evaluate the Python build file:
 

--- a/src/bygg/completions.py
+++ b/src/bygg/completions.py
@@ -1,0 +1,142 @@
+import argparse
+from pathlib import Path
+import shutil
+import sys
+import textwrap
+from typing import Any, Set
+
+from argcomplete.completers import DirectoriesCompleter
+from argcomplete.finders import CompletionFinder
+
+from bygg.output import output_plain
+
+
+class ByggfileDirectoriesCompleter(DirectoriesCompleter):
+    """
+    A completer for directories that contain Bygg files.
+    """
+
+    def __call__(self, prefix, **kwargs):
+        directories = super().__call__(prefix, **kwargs)
+        byggfile_dirs = set()
+        for dir in directories:
+            byggfile_dirs |= {
+                str(b.parent)
+                for b in Path(dir).rglob("Byggfile.*")
+                if b.suffix in {".py", ".yml"}
+            }
+        return sorted(list(byggfile_dirs))
+
+
+def construct_already_there(
+    parser: argparse.ArgumentParser | Any, options: Set[str]
+) -> Set[str]:
+    """
+    Construct a set of options that are already present among the command line
+    arguments. Adds both the short and long versions if they exist.
+    """
+    already_there_set: Set[str] = set()
+    for action in parser._get_optional_actions():
+        option_strings = set(action.option_strings)
+        if option_strings & options:
+            already_there_set.update(option_strings)
+    return already_there_set
+
+
+singular_options = {
+    "--completions",
+    "--dump-schema",
+    "--help",
+    "--version",
+    "-h",
+    "-v",
+}
+
+directory_option = {"-C", "--directory"}
+
+
+class ByggCompletionFinder(CompletionFinder):
+    """
+    Override _get_completions because we want custom completion patterns that are not
+    expressed in argparse.
+    """
+
+    def _get_completions(
+        self, comp_words, cword_prefix, cword_prequote, last_wordbreak_pos
+    ):
+        comp_words_set = set(comp_words)
+
+        # Stop completions if we already have a "singular" option, i.e. an option that
+        # should not be followed by anything else.
+        if comp_words_set & singular_options:
+            return []
+
+        # Get completions from argparse.
+        completions = set(
+            super()._get_completions(
+                comp_words, cword_prefix, cword_prequote, last_wordbreak_pos
+            )
+        )
+
+        # If the last word is a directory, the default completions will be from the
+        # directories completer, so return these.
+        if comp_words[-1] in directory_option:
+            return completions
+
+        action_completions = list(filter(lambda x: not x.startswith("-"), completions))
+        already_there = construct_already_there(self._parser, comp_words_set)
+
+        if comp_words_set & {"--tree", "--clean"}:
+            # Actions if we have them.
+            if action_completions and not cword_prefix.startswith("-"):
+                return action_completions
+            return completions & directory_option - already_there
+
+        if comp_words_set & {"--list"}:
+            # Only complete directories.
+            return completions & directory_option - already_there
+
+        # Return action completions if they exist and user has not entered a '-'.
+        if action_completions and not cword_prefix.startswith("-"):
+            return action_completions
+
+        return completions - already_there
+
+
+def do_completion(parser: argparse.ArgumentParser):
+    completer = ByggCompletionFinder()
+    completer(parser)
+
+
+def generate_shell_completions(print_and_exit: bool):
+    bygg_bin = Path(sys.argv[0])
+    bygg_completions = bygg_bin.resolve().parent / "_bygg_completions.sh"
+    if not bygg_completions.exists():
+        import argcomplete.shell_integration
+
+        with open(bygg_completions, "w") as f:
+            f.write(argcomplete.shell_integration.shellcode([str(bygg_bin.name)]))
+
+    if print_and_exit:
+        terminal_cols, _ = shutil.get_terminal_size()
+        indent_string = "# "
+        width = min(terminal_cols, 80) - len(indent_string)
+        description = f"""\
+            A shell completions script has been generated in {bygg_completions}. It will
+            pick up the bygg that is in PATH. Add the following line to your shell's
+            startup script to load completions:
+        """
+        output_plain(
+            textwrap.indent(
+                textwrap.fill(
+                    textwrap.dedent(description),
+                    width=width,
+                    break_long_words=False,
+                    break_on_hyphens=False,
+                ),
+                indent_string,
+            )
+        )
+        output_plain(f"\nsource {bygg_completions}")
+
+        sys.exit(0)

--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -1,0 +1,158 @@
+# serializer version: 1
+# name: test_actions_completions[checks]
+  list([
+    'all_checks',
+    'check_inputs_outputs',
+    'output_file_missing',
+  ])
+# ---
+# name: test_actions_completions[checks].1
+  list([
+    'all_checks',
+    'check_inputs_outputs',
+    'output_file_missing',
+  ])
+# ---
+# name: test_actions_completions[checks].2
+  list([
+    'all_checks',
+    'check_inputs_outputs',
+    'output_file_missing',
+  ])
+# ---
+# name: test_actions_completions[environments]
+  list([
+    'action1',
+    'action2',
+    'clean_environments',
+    'default_action',
+  ])
+# ---
+# name: test_actions_completions[environments].1
+  list([
+    'action1',
+    'action2',
+    'clean_environments',
+    'default_action',
+  ])
+# ---
+# name: test_actions_completions[environments].2
+  list([
+    'action1',
+    'action2',
+    'clean_environments',
+    'default_action',
+  ])
+# ---
+# name: test_actions_completions[failing_jobs]
+  list([
+    'all',
+    'gcc',
+    'go',
+    'make',
+    'npm',
+  ])
+# ---
+# name: test_actions_completions[failing_jobs].1
+  list([
+    'all',
+    'gcc',
+    'go',
+    'make',
+    'npm',
+  ])
+# ---
+# name: test_actions_completions[failing_jobs].2
+  list([
+    'all',
+    'gcc',
+    'go',
+    'make',
+    'npm',
+  ])
+# ---
+# name: test_actions_completions[only_python]
+  list([
+    'hello',
+  ])
+# ---
+# name: test_actions_completions[only_python].1
+  list([
+    'hello',
+  ])
+# ---
+# name: test_actions_completions[only_python].2
+  list([
+    'hello',
+  ])
+# ---
+# name: test_actions_completions[parametric]
+  list([
+    'setup',
+    'sort',
+  ])
+# ---
+# name: test_actions_completions[parametric].1
+  list([
+    'setup',
+    'sort',
+  ])
+# ---
+# name: test_actions_completions[parametric].2
+  list([
+    'setup',
+    'sort',
+  ])
+# ---
+# name: test_actions_completions[taskrunner]
+  list([
+    'touch\\ a\\ file',
+  ])
+# ---
+# name: test_actions_completions[taskrunner].1
+  list([
+    'touch\\ a\\ file',
+  ])
+# ---
+# name: test_actions_completions[taskrunner].2
+  list([
+    'touch\\ a\\ file',
+  ])
+# ---
+# name: test_actions_completions[trivial]
+  list([
+    'transform',
+  ])
+# ---
+# name: test_actions_completions[trivial].1
+  list([
+    'transform',
+  ])
+# ---
+# name: test_actions_completions[trivial].2
+  list([
+    'transform',
+  ])
+# ---
+# name: test_directory_completions[--directory ]
+  list([
+    'examples/checks',
+    'examples/environments',
+    'examples/failing_jobs',
+    'examples/only_python',
+    'examples/parametric',
+    'examples/taskrunner',
+    'examples/trivial',
+  ])
+# ---
+# name: test_directory_completions[-C ]
+  list([
+    'examples/checks',
+    'examples/environments',
+    'examples/failing_jobs',
+    'examples/only_python',
+    'examples/parametric',
+    'examples/taskrunner',
+    'examples/trivial',
+  ])
+# ---

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+from bygg.completions import ByggCompletionFinder
+from bygg.main import create_argument_parser
+from bygg.system_helpers import change_dir
+import pytest
+
+
+def dummy_exit_method(status):
+    pass
+
+
+def open_raise(*args, **kwargs):
+    raise NotImplementedError
+
+
+@pytest.fixture
+def completion_tester(monkeypatch, tmp_path):
+    def tester(testcase):
+        prefix = "bygg"
+        prefixed_testcase = f"{prefix} {testcase}"
+        outfile = tmp_path / "completion.out"
+
+        # Simulate being run from the completion script:
+        monkeypatch.setenv("_ARGCOMPLETE", "1")
+        monkeypatch.setenv("COMP_LINE", prefixed_testcase)
+        monkeypatch.setenv("COMP_POINT", str(len(prefixed_testcase)))
+        monkeypatch.setenv("_ARGCOMPLETE_STDOUT_FILENAME", str(outfile))
+        # Patch os.fdopen to raise NotImplementedError; this causes argcomplete to use
+        # stderr for debug output instead of opening file descriptor 9, which causes pytest
+        # to get its knickers in a twist.
+        monkeypatch.setattr("os.fdopen", open_raise)
+
+        parser = create_argument_parser()
+        completer = ByggCompletionFinder()
+
+        with open(outfile, "w", encoding="utf-8"):
+            completer(parser, exit_method=dummy_exit_method)
+
+        with open(outfile, "r", encoding="utf-8") as f:
+            return f.read()
+
+    return tester
+
+
+args = [
+    # Complete simple arguments:
+    ("--ver", "--version "),
+    ("--cl", "--clean "),
+    ("--h", "--help "),
+    # No completions after these arguments:
+    ("-h ", ""),
+    ("--help ", ""),
+    ("-v ", ""),
+    ("--version ", ""),
+    ("--dump-schema ", ""),
+    ("--completions ", ""),
+]
+
+
+@pytest.mark.parametrize("arg", args, ids=lambda x: x[0])
+def test_completions(completion_tester, arg):
+    testcase, correct_result = arg
+    testresult = completion_tester(testcase)
+    assert correct_result == testresult
+
+
+# Directories:
+directories_completions = [
+    "-C ",
+    "--directory ",
+]
+
+
+@pytest.mark.parametrize("arg", directories_completions, ids=lambda x: x)
+def test_directory_completions(completion_tester, arg, snapshot):
+    testcase = arg
+    testresult = completion_tester(testcase)
+    assert sorted(testresult.split("\x0b")) == snapshot
+
+
+actions_completions = [p for p in Path("examples").iterdir() if p.is_dir()]
+
+
+@pytest.mark.parametrize("arg", actions_completions, ids=lambda x: str(x.name))
+def test_actions_completions(completion_tester, arg, snapshot, clean_bygg_tree):
+    with change_dir(clean_bygg_tree):
+        dir = str(arg)
+        testcase = f"-C {dir} "
+        testresult = completion_tester(testcase)
+        assert sorted(testresult.split("\x0b")) == snapshot
+
+        testcase = f"--directory {dir} "
+        testresult = completion_tester(testcase)
+        assert sorted(testresult.split("\x0b")) == snapshot
+
+        with change_dir(dir):
+            testresult = completion_tester("")
+            assert sorted(testresult.split("\x0b")) == snapshot


### PR DESCRIPTION
This PR contains a general overhaul of the shell tab completion
integration:

Subclass argcomplete's CompletionFinder and override _get_completions,
since there is a need to filter out arguments depending on which other
arguments that are already on the command line. Not sure if the same
could be achieved by just reworking the argparse usage; this should be
investigated more closely.

Add a custom directories completer that will complete directories with a
Byggfile{.py,.yml} in them.

Add completion for entrypoint actions. This is also supported when there
is subdirectory declared with -C/--directory.

Output a completions file generated by argcomplete to the directory
where the bygg main file is installed.

Add a --completions argument that instructs the user how to activate the
completions in their shell.

Add tests.

Update documentation.