### PR TITLE
Rework status output

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -47,4 +47,9 @@ jobs:
       - name: Type check with Pyright
         run: |
           . .venv/bin/activate
-          pyright examples/ src/ tests/
+          pyright src/ tests/
+
+          # Some examples use Rich in their virtual environments, so install this for Pyright to stay
+          # calm. Errors with regards to use of this dependency will be detected by nox.
+          pip install rich
+          pyright examples/

--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,3 @@ graph-theory==2023.7.4
 msgspec==0.18.4
 multiprocess==0.70.15
 PyYAML==6.0.1 # msgspec requires this as an ambient
-rich==13.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,14 +17,6 @@ dill==0.3.7 \
 graph-theory==2023.7.4 \
     --hash=sha256:847045c4e30b903d8e04a9aa07036b009489a463032b443b519224458621bcce
     # via -r requirements.in
-markdown-it-py==3.0.0 \
-    --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
-    --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
-    # via rich
-mdurl==0.1.2 \
-    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
-    --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
-    # via markdown-it-py
 msgspec==0.18.4 \
     --hash=sha256:227fee75a25080a8b3677cdd95b9c0c3652e27869004a084886c65eb558b3dd6 \
     --hash=sha256:241277eed9fd91037372519fca62aecf823f7229c1d351030d0be5e3302580c1 \
@@ -81,10 +73,6 @@ multiprocess==0.70.15 \
     --hash=sha256:f20eed3036c0ef477b07a4177cf7c1ba520d9a2677870a4f47fe026f0cd6787e \
     --hash=sha256:f7d4a1629bccb433114c3b4885f69eccc200994323c80f6feee73b0edc9199c5
     # via -r requirements.in
-pygments==2.16.1 \
-    --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692 \
-    --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29
-    # via rich
 pyyaml==6.0.1 \
     --hash=sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5 \
     --hash=sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc \
@@ -136,8 +124,4 @@ pyyaml==6.0.1 \
     --hash=sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585 \
     --hash=sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d \
     --hash=sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f
-    # via -r requirements.in
-rich==13.6.0 \
-    --hash=sha256:2b38e2fe9ca72c9a00170a1a2d20c63c790d0e10ef1fe35eba76e1e7b1d7d245 \
-    --hash=sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef
     # via -r requirements.in

--- a/src/bygg/apply_configuration.py
+++ b/src/bygg/apply_configuration.py
@@ -2,11 +2,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
-import time
 from typing import List
-
-import rich
-import rich.status
 
 from bygg.action import Action
 from bygg.configuration import (
@@ -17,7 +13,6 @@ from bygg.configuration import (
 )
 from bygg.digest import calculate_string_digest
 from bygg.output import output_error, output_info, output_plain
-from bygg.scheduler import scheduler
 from bygg.util import create_shell_command
 
 
@@ -29,11 +24,6 @@ def calculate_environment_hash(environment: Environment) -> str:
             with open(input, "r") as f:
                 requirements += f.readlines()
     return calculate_string_digest(" ".join(requirements))
-
-
-loading_python_build_file = rich.status.Status(
-    "[cyan]Executing Python build file", spinner="dots"
-)
 
 
 def setup_environment(environment: Environment):
@@ -133,14 +123,6 @@ def apply_configuration(
         if environment:
             python_build_file = environment.byggfile
 
-    t0 = time.time()
-    action_count = len(scheduler.build_actions)
-
-    with loading_python_build_file:
-        load_python_build_file(python_build_file)
-    output_info(
-        f"{len(scheduler.build_actions) - action_count} actions registered in "
-        f"{time.time() - t0:.2f} seconds."
-    )
+    load_python_build_file(python_build_file)
 
     return None

--- a/src/bygg/configuration.py
+++ b/src/bygg/configuration.py
@@ -3,8 +3,9 @@ import sys
 from typing import Dict, List, Optional
 
 import msgspec
-import rich
-import rich.status
+
+from bygg.output import Symbols, output_plain
+from bygg.output import TerminalStyle as TS
 
 PYTHON_INPUTFILE = "Byggfile.py"
 YAML_INPUTFILE = "Byggfile.yml"
@@ -87,9 +88,12 @@ def read_config_file() -> ByggFile | None:
         with open(YAML_INPUTFILE, "r") as f:
             return msgspec.yaml.decode(f.read(), type=ByggFile)
     except Exception as e:
-        rich.print(
-            "[red bold]Error while reading configuration file "
-            f"[yellow]{YAML_INPUTFILE}[/yellow]:[/red bold] {e}"
+        output_plain(
+            Symbols.RED_X
+            + TS.Fg.RED
+            + " Error while reading configuration file "
+            + TS.Fg.RESET
+            + f"{TS.BOLD}{YAML_INPUTFILE}{TS.RESET}. {e}"
         )
         sys.exit(1)
 

--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -38,7 +38,6 @@ from bygg.status_display import (
     on_job_status,
     on_runner_status,
     output_check_results,
-    progress,
 )
 
 
@@ -90,15 +89,12 @@ def build(
             t1 = time.time()
             output_info(f"Building action '{action}':")
 
-            progress.start()
             scheduler.start_run(
                 action,
                 always_make=always_make,
                 check=check,
             )
             status = runner.start(max_workers)
-            progress.disable
-            progress.stop()
             scheduler.shutdown()
 
             if status:
@@ -108,23 +104,13 @@ def build(
                     f"Action '{action}' failed after {time.time() - t1:.2f} s."
                 )
 
-            # cs = build(action)
-            # if cs is None:
-            #     rich.print(f"Action '{action}' is up to date.")
-            # else:
-            #     rich.print(f"Action '{action}' completed with return code {cs.rc}.")
-            #     rich.print(
-            #         f"{len(cs.changed_files)} files changed in {time() - t1:.2f} s."
-            #     )
-            # rich.print("=========================================")
     except KeyboardInterrupt:
-        output_warning("\n[yellow]Build was interrupted by user.[/yellow]")
+        output_warning("\nBuild was interrupted by user.")
         return False
     except KeyError as e:
         output_error(f"Error: Action '{e}' not found.")
         return False
     finally:
-        progress.stop()
         scheduler.shutdown()
 
     if check and failed_checks:
@@ -162,7 +148,6 @@ def clean(actions: List[str]):
         output_error(f"Error: Action '{e}' not found.")
         return False
     finally:
-        progress.stop()
         scheduler.shutdown()
 
     return True
@@ -226,14 +211,7 @@ def list_actions(configuration: ByggFile | None) -> bool:
             )
             output.append("")
 
-    if len(output) > terminal_rows:
-        from rich.console import Console
-
-        console = Console()
-        with console.pager():
-            console.print("\n".join(output))
-    else:
-        print("\n".join(output))
+    print("\n".join(output))
 
     return True
 

--- a/src/bygg/output.py
+++ b/src/bygg/output.py
@@ -6,6 +6,7 @@ isatty = sys.stdout.isatty()
 class TerminalStyle:
     """Terminal Text Styling"""
 
+    CLEARLINE = "\033[2K\r" if isatty else ""
     RESET = "\033[0m" if isatty else ""
     BOLD = "\033[1m" if isatty else ""
     DIM = "\033[2m" if isatty else ""
@@ -41,8 +42,32 @@ class TerminalStyle:
         RESET = "\033[49m" if isatty else ""
 
 
+class Symbols:
+    GREEN_CHECKMARK = f"{TerminalStyle.Fg.GREEN}✓{TerminalStyle.Fg.RESET}"
+    RED_X = f"{ TerminalStyle.Fg.RED }✗{TerminalStyle.Fg.RESET}"
+    INFO = f"{TerminalStyle.Fg.BLUE}🛈{TerminalStyle.Fg.RESET}"
+
+
+def output_with_status_line(bottom: str | None, scroll: str | None):
+    """
+    Outputs a line of text at the bottom of the terminal which is cleared and reprinted,
+    and another line of text that scrolls up.
+
+    Only prints the latter if the terminal is not a tty.
+    """
+    if not isatty:
+        print(scroll)
+        return
+
+    print(TerminalStyle.CLEARLINE, end="")
+
+    if scroll is not None:
+        print(scroll)
+    print(bottom if bottom is not None else "", end="\r")
+
+
 def output_info(s: str):
-    print(f"{TerminalStyle.Fg.BLUE}{s}{TerminalStyle.Fg.RESET}")
+    print(f"{Symbols.INFO} {s}")
 
 
 def output_warning(s: str):

--- a/src/bygg/runner.py
+++ b/src/bygg/runner.py
@@ -7,6 +7,7 @@ from multiprocess.pool import ApplyResult, Pool  # type: ignore
 
 from bygg.action import Action, CommandStatus
 from bygg.common_types import JobStatus
+from bygg.output import TerminalStyle as TS
 from bygg.scheduler import Job, scheduler
 from bygg.status_display import on_check_failed
 
@@ -24,7 +25,7 @@ class ProcessRunner:
 
     def start(self, max_workers: int = 1) -> bool:
         self.runner_status_listener(
-            f"[blue]Starting process runner with {max_workers} threads"
+            f"Starting process runner with {max_workers} threads"
         )
 
         def init_worker():
@@ -113,7 +114,7 @@ class ProcessRunner:
                         on_check_failed(
                             "output_file_missing",
                             job_result.action,
-                            f"Job [bold]{job_result.name}[/bold] didn't create the output file{'s' if len(missing_files) > 1 else ''} that it declared: [bold]{', '.join(missing_files)}[/bold]",
+                            f"Job {TS.BOLD}{job_result.name}{TS.RESET} didn't create the output file{'s' if len(missing_files) > 1 else ''} that it declared: {TS.BOLD}{', '.join(missing_files)}{TS.RESET}",
                             "error",
                         )
 


### PR DESCRIPTION
- Remove dependency on Rich from the core code. Rich has a number of
  relatively heavy dependencies, and is also not as fast as regular
  print.
- Work around Pyright testing in the Code quality GitHub Action workflow
  by installing Rich before checking the examples. This is needed
  because the the environments example installs Rich in its virtual
  environments, which Pyright knows nothing about.
- Remove progress indicators.
- Remove pager introduced in 627ea510c726ebfd8ea45f0fe52f318f0c8fa679.
- Remove some uninteresting output.
- Add Symbols abstraction for different status types.
- Implement a function that outputs a fixed status line for the build
  output. It currently shows the queued jobs, while the lines for the
  finished jobs scroll up.

Work on https://github.com/rikardg/bygg/issues/28.