### PR TITLE
Remove scheduler and runner global objects

### DIFF
--- a/src/bygg/action.py
+++ b/src/bygg/action.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Callable, Iterable, Literal, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Callable, Iterable, Literal, Optional, Set, Tuple
 
 from bygg.common_types import CommandStatus
+
+if TYPE_CHECKING:
+    from bygg.scheduler import Scheduler
 
 SchedulingType = Literal["in-process", "processpool"]
 
@@ -42,6 +47,8 @@ class Action(ActionContext):
 
     """
 
+    scheduler: Scheduler | None = None
+
     command: Command | None
     dependency_files: Set[str]
 
@@ -58,8 +65,6 @@ class Action(ActionContext):
         command: Command | None = None,
         scheduling_type: SchedulingType = "processpool",
     ):
-        from bygg.scheduler import scheduler
-
         self.name = name
         self.description = description
         self.message = message
@@ -73,7 +78,8 @@ class Action(ActionContext):
 
         self.dependency_files = set()
 
-        scheduler.build_actions[name] = self
+        assert self.scheduler
+        self.scheduler.build_actions[name] = self
 
     def __repr__(self):
         return f"""Action(name={self.name}, inputs=({

--- a/src/bygg/scheduler.py
+++ b/src/bygg/scheduler.py
@@ -53,6 +53,7 @@ class Scheduler:
     check_inputs_outputs_set: Set[str] | None
 
     def __init__(self):
+        Action.scheduler = self
         self.cache = Cache()
         self.build_actions = {}
         self.job_graph = create_dag()
@@ -251,6 +252,3 @@ class Scheduler:
             )
         else:
             self.cache.remove_digests(job.name)
-
-
-scheduler = Scheduler()

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,7 +1,16 @@
 from bygg.action import Action, ActionContext, CommandStatus
+from bygg.scheduler import Scheduler
+import pytest
 
 
-def test_Action_setup_empty():
+@pytest.fixture
+def init_scheduler():
+    Scheduler()
+    yield
+    Action.scheduler = None
+
+
+def test_Action_setup_empty(init_scheduler):
     action = Action(name="empty Action", inputs=None, outputs=None, dependencies=None)
     assert action.name == "empty Action"
     assert action.inputs == set()
@@ -11,7 +20,7 @@ def test_Action_setup_empty():
     assert action.command is None
 
 
-def test_Action_setup_with_dependencies():
+def test_Action_setup_with_dependencies(init_scheduler):
     action = Action(
         name="test Action",
         inputs=["input1", "input2"],
@@ -27,7 +36,7 @@ def test_Action_setup_with_dependencies():
     assert action.command is None
 
 
-def test_Action_with_python_cmd():
+def test_Action_with_python_cmd(init_scheduler):
     def test_command(ctx: ActionContext):
         if not ctx.inputs:
             return CommandStatus(1, "No inputs.", None)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tempfile import mkstemp
 
 from bygg.action import Action, CommandStatus
-from bygg.scheduler import scheduler
+from bygg.scheduler import Scheduler
 
 
 def get_closed_tmpfile() -> Path:
@@ -13,6 +13,7 @@ def get_closed_tmpfile() -> Path:
 
 
 def test_scheduler_single_action():
+    scheduler = Scheduler()
     scheduler.__init__()
     scheduler.init_cache(get_closed_tmpfile())
 
@@ -41,6 +42,7 @@ def test_scheduler_single_action():
 
 
 def test_scheduler_nonbranching():
+    scheduler = Scheduler()
     scheduler.__init__()
     scheduler.init_cache(get_closed_tmpfile())
 
@@ -110,6 +112,7 @@ def test_scheduler_nonbranching():
 
 
 def test_scheduler_branching():
+    scheduler = Scheduler()
     scheduler.__init__()
     scheduler.init_cache(get_closed_tmpfile())
 
@@ -187,6 +190,7 @@ def test_scheduler_branching():
 
 
 def test_scheduler_branching_one_failed():
+    scheduler = Scheduler()
     scheduler.__init__()
     scheduler.init_cache(get_closed_tmpfile())
 
@@ -258,6 +262,7 @@ def test_scheduler_branching_one_failed():
 
 
 def test_scheduler_dynamic_dependency():
+    scheduler = Scheduler()
     scheduler.__init__()
     cache_file = get_closed_tmpfile()
     scheduler.init_cache(cache_file)
@@ -300,6 +305,7 @@ def test_scheduler_dynamic_dependency():
 
 
 def test_scheduler_dynamic_dependency_two_runs():
+    scheduler = Scheduler()
     scheduler.__init__()
     cache_file = get_closed_tmpfile()
     scheduler.init_cache(cache_file)


### PR DESCRIPTION
Don't create the runner and scheduler objects in their respective source files. Instead create them explicitly from where they're going to be used, and connect them to each other there.

Set the scheduler object as a class variable on the Action class when the scheduler is initialised instead of using the global.

This is a cleaner and more decoupled design that improves testability of the system.