### PR TITLE
Pytest work

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -18,7 +18,6 @@ def test_cache_load_non_existing():
 
 def test_cache_load_empty():
     fd, path = mkstemp()
-    print(path)
     cache = Cache(Path(path))
     cache.load()
     assert cache.data is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,36 +1,53 @@
 from bygg.action import Action
 from bygg.util import create_shell_command, filenames_from_pattern
+import pytest
+
+test_cases_filenames_from_pattern = [
+    (
+        (
+            ["/foo/bar/baz.txt.j2"],
+            "%.j2",
+            "out_%",
+            [("/foo/bar/baz.txt.j2", "/foo/bar/out_baz.txt")],
+        )
+    ),
+    (
+        (
+            ["/foo/bar/baz.txt.j2"],
+            "%.txt.j2",
+            "out_%.txt",
+            [("/foo/bar/baz.txt.j2", "/foo/bar/out_baz.txt")],
+        )
+    ),
+    (
+        (
+            ["foo.c", "bar.c"],
+            "%.c",
+            "%.o",
+            [("foo.c", "foo.o"), ("bar.c", "bar.o")],
+        )
+    ),
+    (
+        (
+            ["foo.txt", "bar.txt"],
+            "%",
+            "out_%",
+            [("foo.txt", "out_foo.txt"), ("bar.txt", "out_bar.txt")],
+        )
+    ),
+]
 
 
-def test_filenames_from_pattern_1():
-    input_files = ["/foo/bar/baz.txt.j2"]
-    in_pattern = "%.j2"
-    out_pattern = "out_%"
-    output_files = [("/foo/bar/baz.txt.j2", "/foo/bar/out_baz.txt")]
-    assert filenames_from_pattern(input_files, in_pattern, out_pattern) == output_files
+def construct_test_case_name(x: tuple):
+    a, b, c, d = x
+    return f"{b} | {c}"
 
 
-def test_filenames_from_pattern_2():
-    input_files = ["/foo/bar/baz.txt.j2"]
-    in_pattern = "%.txt.j2"
-    out_pattern = "out_%.txt"
-    output_files = [("/foo/bar/baz.txt.j2", "/foo/bar/out_baz.txt")]
-    assert filenames_from_pattern(input_files, in_pattern, out_pattern) == output_files
-
-
-def test_filenames_from_pattern_3():
-    input_files = ["foo.c", "bar.c"]
-    in_pattern = "%.c"
-    out_pattern = "%.o"
-    output_files = [("foo.c", "foo.o"), ("bar.c", "bar.o")]
-    assert filenames_from_pattern(input_files, in_pattern, out_pattern) == output_files
-
-
-def test_filenames_from_pattern_4():
-    input_files = ["foo.txt", "bar.txt"]
-    in_pattern = "%"
-    out_pattern = "out_%"
-    output_files = [("foo.txt", "out_foo.txt"), ("bar.txt", "out_bar.txt")]
+@pytest.mark.parametrize(
+    "test_case", test_cases_filenames_from_pattern, ids=construct_test_case_name
+)
+def test_filenames_from_pattern(test_case):
+    input_files, in_pattern, out_pattern, output_files = test_case
     assert filenames_from_pattern(input_files, in_pattern, out_pattern) == output_files
 
 


### PR DESCRIPTION
## Remove a stray print from test_cache.py.

## Use a fixture for the scheduler tests

Use a fixture to set up the temp directory and cache file for the
scheduler tests.

## Parametrize the tests for filenames_from_pattern.

