### PR TITLE
Add snapshot tests for the --tree option

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ pyright==1.1.332
 pytest==7.4.2
 ruff==0.1.1
 setuptools==68.0.0
+syrupy==4.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -134,7 +134,9 @@ pyright==1.1.332 \
 pytest==7.4.2 \
     --hash=sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002 \
     --hash=sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069
-    # via -r requirements-dev.in
+    # via
+    #   -r requirements-dev.in
+    #   syrupy
 ruff==0.1.1 \
     --hash=sha256:2a909d3930afdbc2e9fd893b0034479e90e7981791879aab50ce3d9f55205bd6 \
     --hash=sha256:2d68367d1379a6b47e61bc9de144a47bcdb1aad7903bbf256e4c3d31f11a87ae \
@@ -153,6 +155,10 @@ ruff==0.1.1 \
     --hash=sha256:d3f9ac658ba29e07b95c80fa742b059a55aefffa8b1e078bc3c08768bdd4b11a \
     --hash=sha256:e140bd717c49164c8feb4f65c644046fe929c46f42493672853e3213d7bdbce2 \
     --hash=sha256:f4780e2bb52f3863a565ec3f699319d3493b83ff95ebbb4993e59c62aaf6e75e
+    # via -r requirements-dev.in
+syrupy==4.6.0 \
+    --hash=sha256:231b1f5d00f1f85048ba81676c79448076189c4aef4d33f21ae32f3b4c565a54 \
+    --hash=sha256:747aae1bcf3cb3249e33b1e6d81097874d23615982d5686ebe637875b0775a1b
     # via -r requirements-dev.in
 typing-extensions==4.8.0 \
     --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \

--- a/tests/__snapshots__/test_tree.ambr
+++ b/tests/__snapshots__/test_tree.ambr
@@ -1,0 +1,29 @@
+# serializer version: 1
+# name: test_tree_branching_actions
+  '''
+  
+  action1
+  ├── action2
+  │   └── action4
+  └── action3
+      └── action4
+  
+  '''
+# ---
+# name: test_tree_four_nonbranching_actions
+  '''
+  
+  action1
+  └── action2
+      └── action3
+          └── action4
+  
+  '''
+# ---
+# name: test_tree_single_action
+  '''
+  
+  action1
+  
+  '''
+# ---

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,24 @@
+from bygg.tree import display_tree
+
+
+def test_tree_single_action(scheduler_single_action, capsys, snapshot):
+    scheduler, _ = scheduler_single_action
+    display_tree(scheduler, ["action1"])
+    stdout, _ = capsys.readouterr()
+    assert stdout == snapshot
+
+
+def test_tree_four_nonbranching_actions(
+    scheduler_four_nonbranching_actions, capsys, snapshot
+):
+    scheduler, _ = scheduler_four_nonbranching_actions
+    display_tree(scheduler, ["action1"])
+    stdout, _ = capsys.readouterr()
+    assert stdout == snapshot
+
+
+def test_tree_branching_actions(scheduler_branching_actions, capsys, snapshot):
+    scheduler, _ = scheduler_branching_actions
+    display_tree(scheduler, ["action1"])
+    stdout, _ = capsys.readouterr()
+    assert stdout == snapshot


### PR DESCRIPTION
- Add the syrupy pytest plugin for snapshot testing.
- Add snapshot tests for the --tree option.