### PR TITLE
Add output of failing jobs

### DIFF
--- a/examples/failing_jobs/Byggfile.yml
+++ b/examples/failing_jobs/Byggfile.yml
@@ -1,0 +1,24 @@
+settings:
+  default_action: all
+
+actions:
+  - name: "all"
+    description: Run all test jobs. They will fail.
+    is_entrypoint: true
+    dependencies: ["gcc", "npm", "go", "make"]
+
+  - name: "gcc"
+    description: Simulate a failing gcc build.
+    shell: cat testdata/gcc.log && false
+
+  - name: "npm"
+    description: Simulate a failing npm build.
+    shell: cat testdata/npm.log && false
+
+  - name: "go"
+    description: Simulate a failing go build.
+    shell: cat testdata/go.log && false
+
+  - name: "make"
+    description: Simulate a failing make run.
+    shell: cat testdata/make.log && false

--- a/examples/failing_jobs/testdata/gcc.log
+++ b/examples/failing_jobs/testdata/gcc.log
@@ -1,0 +1,33 @@
+# Simulated GCC Log
+
+main.c: In function ‘main’:
+main.c:5:5: warning: implicit declaration of function ‘foo’ [-Wimplicit-function-declaration]
+    foo();
+    ^~~
+main.c:5:5: warning: unused variable ‘a’ [-Wunused-variable]
+    int a = 5;
+    ^~~
+main.c:6:5: warning: unused variable ‘b’ [-Wunused-variable]
+    int b = 10;
+    ^~~
+main.c:7:5: warning: unused variable ‘c’ [-Wunused-variable]
+    int c = a + b;
+    ^~~
+main.c:8:5: warning: unused variable ‘d’ [-Wunused-variable]
+    int d = c * 2;
+    ^~~
+main.c:9:5: warning: unused variable ‘e’ [-Wunused-variable]
+    int e = d / 3;
+    ^~~
+main.c:10:5: warning: unused variable ‘f’ [-Wunused-variable]
+    int f = e % 2;
+    ^~~
+main.c:11:5: warning: unused variable ‘g’ [-Wunused-variable]
+    int g = f + 1;
+    ^~~
+main.c:12:5: warning: unused variable ‘h’ [-Wunused-variable]
+    int h = g - 1;
+    ^~~
+main.c:13:5: error: expected declaration or statement at end of input
+    return 0;
+    ^~~~~~

--- a/examples/failing_jobs/testdata/go.log
+++ b/examples/failing_jobs/testdata/go.log
@@ -1,0 +1,11 @@
+# Simulated Go Compiler Log
+
+Compiling package: example_package
+
+./main.go:5:15: warning: unused import "fmt"
+./main.go:6:9: warning: unused variable "unusedVar"
+./main.go:8:18: warning: type assertion in non-type context
+./main.go:10:11: warning: variable "x" declared and not used
+
+./util.go:4:20: warning: exported function SomeFunction should have a comment or be unexported
+./util.go:12:1: error: undefined: undeclaredVar

--- a/examples/failing_jobs/testdata/make.log
+++ b/examples/failing_jobs/testdata/make.log
@@ -1,0 +1,19 @@
+# Simulated Make Log
+
+Building target: my_program
+
+Compiling source file main.c...
+gcc -c main.c -o main.o
+
+Compiling source file utils.c...
+gcc -c utils.c -o utils.o
+utils.c: In function 'int divide(int, int)':
+utils.c:6: warning: division by zero [-Wdiv-by-zero]
+
+Compiling source file module.cpp...
+g++ -c module.cpp -o module.o
+module.cpp: In function 'void someFunction()':
+module.cpp:12: error: 'undeclaredVar' was not declared in this scope
+
+Makefile:12: recipe for target 'my_program' failed
+make: *** [my_program] Error 1

--- a/examples/failing_jobs/testdata/npm.log
+++ b/examples/failing_jobs/testdata/npm.log
@@ -1,0 +1,17 @@
+# Simulated npm Log
+
+npm WARN package.json YourProjectName@1.0.0 No repository field.
+npm WARN deprecated some-package@1.2.3: This package has been deprecated. Please use the latest version.
+npm WARN optional dep failed, continuing @optional/package@4.5.6
+npm ERR! code E404
+npm ERR! 404 Not Found - GET https://registry.npmjs.org/nonexistent-package - Not found
+
+npm ERR! A complete log of this run can be found in:
+npm ERR!     /home/user/.npm/_logs/2023-10-27T14_32_15_617Z-debug.log
+
+npm WARN optional dep failed, continuing @optional/package@4.5.6
+npm ERR! code E403
+npm ERR! 403 Forbidden - PUT https://registry.npmjs.org/some-package - You do not have permission to publish "some-package". Are you logged in?
+
+npm ERR! A complete log of this run can be found in:
+npm ERR!     /home/user/.npm/_logs/2023-10-27T14_32_30_509Z-debug.log

--- a/src/bygg/job_output.py
+++ b/src/bygg/job_output.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+import re
+from typing import List
+
+from bygg.output import TerminalStyle as TS
+from bygg.output import isatty, output_plain
+from bygg.scheduler import Job
+
+
+@dataclass
+class HighlightConfig:
+    pattern: str | re.Pattern[str]
+    start: str
+    end: str
+
+
+warning_hl_config = HighlightConfig(
+    pattern=r"(warn\w*:?|WARN\w*:?)",
+    start=TS.Bg.YELLOW + TS.Fg.BLACK,
+    end=TS.Fg.RESET + TS.Bg.RESET,
+)
+
+error_hl_config = HighlightConfig(
+    pattern=r"(error\w*:?|ERR!)",
+    start=TS.Bg.RED,
+    end=TS.Fg.RESET + TS.Bg.RESET,
+)
+
+default_highlight_config: List[HighlightConfig] = [warning_hl_config, error_hl_config]
+
+
+def highlight_log(message: str, config: List[HighlightConfig] | None = None):
+    """
+    Highlights the message according to the regexes and styles. Regexes are applied
+    per line.
+    """
+    if not config:
+        return message
+
+    lines = []
+    for line in message.splitlines():
+        for c in config:
+            line = re.sub(c.pattern, c.start + r"\1" + c.end, line, flags=re.IGNORECASE)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def output_job_logs(jobs: List[Job]):
+    print(
+        f"\n{TS.BOLD}Showing logs for {len(jobs)} failed job{'s' if len(jobs) > 1 else ''}:{TS.RESET}\n"
+    )
+    for job in jobs:
+        if job.status and (log := job.status.output):
+            output_plain(f'{TS.BOLD}--- Start "{ job.name }" ---{TS.RESET}')
+            output_plain(
+                highlight_log(log, default_highlight_config) if isatty else log
+            )
+            output_plain(f'{TS.BOLD}--- End "{ job.name}" ---{TS.RESET}')
+            output_plain("")

--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -22,6 +22,7 @@ from bygg.configuration import (
     dump_schema,
     read_config_file,
 )
+from bygg.job_output import output_job_logs
 from bygg.output import (
     TerminalStyle as TS,
 )
@@ -115,6 +116,8 @@ def build(
                 output_error(
                     f"Action '{action}' failed after {time.time() - t1:.2f} s."
                 )
+                output_job_logs(ctx.runner.failed_jobs)
+                return False
 
     except KeyboardInterrupt:
         output_warning("\nBuild was interrupted by user.")

--- a/tests/__snapshots__/test_job_output.ambr
+++ b/tests/__snapshots__/test_job_output.ambr
@@ -1,0 +1,118 @@
+# serializer version: 1
+# name: test_highlight_warning
+  '''
+  
+  main.c: In function ‘main’:
+  main.c:5:5: [START_WARNING]warning:[END_WARNING] implicit declaration of function ‘foo’ [-Wimplicit-function-declaration]
+      foo();
+      ^~~
+  main.c:5:5: [START_WARNING]warning:[END_WARNING] unused variable ‘a’ [-Wunused-variable]
+      int a = 5;
+      ^~~
+  main.c:6:5: [START_WARNING]warning:[END_WARNING] unused variable ‘b’ [-Wunused-variable]
+      int b = 10;
+      ^~~
+  main.c:7:5: [START_WARNING]warning:[END_WARNING] unused variable ‘c’ [-Wunused-variable]
+      int c = a + b;
+      ^~~
+  main.c:9:5: [START_ERROR]error:[END_ERROR] expected declaration or statement at end of input
+      return 0;
+      ^~~~~~
+  '''
+# ---
+# name: test_highlight_warning_logfiles[gcc.log]
+  '''
+  # Simulated GCC Log
+  
+  main.c: In function ‘main’:
+  main.c:5:5: [START_WARNING]warning:[END_WARNING] implicit declaration of function ‘foo’ [-Wimplicit-function-declaration]
+      foo();
+      ^~~
+  main.c:5:5: [START_WARNING]warning:[END_WARNING] unused variable ‘a’ [-Wunused-variable]
+      int a = 5;
+      ^~~
+  main.c:6:5: [START_WARNING]warning:[END_WARNING] unused variable ‘b’ [-Wunused-variable]
+      int b = 10;
+      ^~~
+  main.c:7:5: [START_WARNING]warning:[END_WARNING] unused variable ‘c’ [-Wunused-variable]
+      int c = a + b;
+      ^~~
+  main.c:8:5: [START_WARNING]warning:[END_WARNING] unused variable ‘d’ [-Wunused-variable]
+      int d = c * 2;
+      ^~~
+  main.c:9:5: [START_WARNING]warning:[END_WARNING] unused variable ‘e’ [-Wunused-variable]
+      int e = d / 3;
+      ^~~
+  main.c:10:5: [START_WARNING]warning:[END_WARNING] unused variable ‘f’ [-Wunused-variable]
+      int f = e % 2;
+      ^~~
+  main.c:11:5: [START_WARNING]warning:[END_WARNING] unused variable ‘g’ [-Wunused-variable]
+      int g = f + 1;
+      ^~~
+  main.c:12:5: [START_WARNING]warning:[END_WARNING] unused variable ‘h’ [-Wunused-variable]
+      int h = g - 1;
+      ^~~
+  main.c:13:5: [START_ERROR]error:[END_ERROR] expected declaration or statement at end of input
+      return 0;
+      ^~~~~~
+  '''
+# ---
+# name: test_highlight_warning_logfiles[go.log]
+  '''
+  # Simulated Go Compiler Log
+  
+  Compiling package: example_package
+  
+  ./main.go:5:15: [START_WARNING]warning:[END_WARNING] unused import "fmt"
+  ./main.go:6:9: [START_WARNING]warning:[END_WARNING] unused variable "unusedVar"
+  ./main.go:8:18: [START_WARNING]warning:[END_WARNING] type assertion in non-type context
+  ./main.go:10:11: [START_WARNING]warning:[END_WARNING] variable "x" declared and not used
+  
+  ./util.go:4:20: [START_WARNING]warning:[END_WARNING] exported function SomeFunction should have a comment or be unexported
+  ./util.go:12:1: [START_ERROR]error:[END_ERROR] undefined: undeclaredVar
+  '''
+# ---
+# name: test_highlight_warning_logfiles[make.log]
+  '''
+  # Simulated Make Log
+  
+  Building target: my_program
+  
+  Compiling source file main.c...
+  gcc -c main.c -o main.o
+  
+  Compiling source file utils.c...
+  gcc -c utils.c -o utils.o
+  utils.c: In function 'int divide(int, int)':
+  utils.c:6: [START_WARNING]warning:[END_WARNING] division by zero [-Wdiv-by-zero]
+  
+  Compiling source file module.cpp...
+  g++ -c module.cpp -o module.o
+  module.cpp: In function 'void someFunction()':
+  module.cpp:12: [START_ERROR]error:[END_ERROR] 'undeclaredVar' was not declared in this scope
+  
+  Makefile:12: recipe for target 'my_program' failed
+  make: *** [my_program] Error 1
+  '''
+# ---
+# name: test_highlight_warning_logfiles[npm.log]
+  '''
+  # Simulated npm Log
+  
+  npm WARN package.json YourProjectName@1.0.0 No repository field.
+  npm WARN deprecated some-package@1.2.3: This package has been deprecated. Please use the latest version.
+  npm WARN optional dep failed, continuing @optional/package@4.5.6
+  npm ERR! code E404
+  npm ERR! 404 Not Found - GET https://registry.npmjs.org/nonexistent-package - Not found
+  
+  npm ERR! A complete log of this run can be found in:
+  npm ERR!     /home/user/.npm/_logs/2023-10-27T14_32_15_617Z-debug.log
+  
+  npm WARN optional dep failed, continuing @optional/package@4.5.6
+  npm ERR! code E403
+  npm ERR! 403 Forbidden - PUT https://registry.npmjs.org/some-package - You do not have permission to publish "some-package". Are you logged in?
+  
+  npm ERR! A complete log of this run can be found in:
+  npm ERR!     /home/user/.npm/_logs/2023-10-27T14_32_30_509Z-debug.log
+  '''
+# ---

--- a/tests/test_job_output.py
+++ b/tests/test_job_output.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from bygg.job_output import HighlightConfig, highlight_log
+import pytest
+
+short_gcc_log = """
+main.c: In function ‘main’:
+main.c:5:5: warning: implicit declaration of function ‘foo’ [-Wimplicit-function-declaration]
+    foo();
+    ^~~
+main.c:5:5: warning: unused variable ‘a’ [-Wunused-variable]
+    int a = 5;
+    ^~~
+main.c:6:5: warning: unused variable ‘b’ [-Wunused-variable]
+    int b = 10;
+    ^~~
+main.c:7:5: warning: unused variable ‘c’ [-Wunused-variable]
+    int c = a + b;
+    ^~~
+main.c:9:5: error: expected declaration or statement at end of input
+    return 0;
+    ^~~~~~
+"""
+
+
+def test_no_config():
+    assert highlight_log(short_gcc_log) == short_gcc_log
+
+
+config = [
+    HighlightConfig(
+        pattern=r"(warning:)",
+        start="[START_WARNING]",
+        end="[END_WARNING]",
+    ),
+    HighlightConfig(
+        pattern=r"(error:)",
+        start="[START_ERROR]",
+        end="[END_ERROR]",
+    ),
+]
+
+
+def test_highlight_warning(snapshot):
+    print(highlight_log(short_gcc_log, config))
+    assert highlight_log(short_gcc_log, config) == snapshot
+
+
+testdata_path = Path("examples/failing_jobs/testdata/")
+logfiles = ["gcc.log", "go.log", "make.log", "npm.log"]
+
+
+@pytest.mark.parametrize("logfile", logfiles, ids=lambda x: x)
+def test_highlight_warning_logfiles(snapshot, logfile):
+    with open(testdata_path / logfile) as f:
+        log = f.read()
+    assert highlight_log(log, config) == snapshot


### PR DESCRIPTION
Output the logs of failing jobs with certain keywords highlighted for warnings and errors, respectively.

Have the runner finish the currently running jobs if one fails and then return False.

Add examples and test cases with simulated logs.