### PR TITLE
Adjust entrypoints in examples/*/Byggfile.yml

### DIFF
--- a/examples/checks/Byggfile.yml
+++ b/examples/checks/Byggfile.yml
@@ -6,18 +6,19 @@ actions:
     description: |
       Run all test actions declared in this file. Should trigger all tested checks when run with
       --check.
-    is_entrypoint: true
     dependencies:
       - check_inputs_outputs
       - output_file_missing
 
   # Circular dependencies
   - name: "circular_A"
+    is_entrypoint: false
     outputs: ["foo"]
     shell: |
       touch foo
 
   - name: "circular_B"
+    is_entrypoint: false
     dependencies: ["circular_A"]
     inputs: ["foo"]
     outputs: ["bar"]
@@ -25,6 +26,7 @@ actions:
       touch bar
 
   - name: "circular_C"
+    is_entrypoint: false
     dependencies: ["circular_B"]
     inputs: ["bar"]
     outputs: ["foo"]
@@ -33,7 +35,6 @@ actions:
     description: |
       Example where a later action has the input of an earlier one as its output. This should
       trigger check_inputs_outputs when run with --check.
-    is_entrypoint: true
     dependencies: ["circular_C"]
 
   # Actions that don't create their outputs
@@ -41,12 +42,12 @@ actions:
     description: |
       Example that doesn't create the outputs that it declares. This should trigger
       output_file_missing when run with --check.
-    is_entrypoint: true
     dependencies: ["no_outputs_A"]
     inputs: ["no_outputs_A"]
     outputs: ["no_outputs"]
     shell: "true"
 
   - name: "no_outputs_A"
+    is_entrypoint: false
     outputs: ["no_outputs_A"]
     shell: "true"

--- a/examples/environments/Byggfile.yml
+++ b/examples/environments/Byggfile.yml
@@ -7,26 +7,22 @@ actions:
     message: "Cleaning"
     shell: |
       rm -Rf .venv .venv1 .venv2
-    is_entrypoint: true
 
   - name: "default_action"
     description: "The default action. Runs in the default environment."
     message: "Running in default env"
     dependencies: ["default_action_python"]
-    is_entrypoint: true
 
   - name: "action1"
     description: "Action that runs in env1."
     message: "Running in env1"
     dependencies: ["action1_python"]
-    is_entrypoint: true
     environment: "env1"
 
   - name: "action2"
     description: "Action that runs in env2."
     message: "Running in env2"
     dependencies: ["action2_python"]
-    is_entrypoint: true
     environment: "env2"
 
 environments:

--- a/examples/parametric/Byggfile.yml
+++ b/examples/parametric/Byggfile.yml
@@ -4,10 +4,8 @@ settings:
 actions:
   - name: "sort"
     description: "Sort all test files. Also sets up test files if needed."
-    is_entrypoint: true
     dependencies: ["sort_test_files"]
 
   - name: "setup"
     description: "Set up test files."
-    is_entrypoint: true
     dependencies: ["setup_test_files"]

--- a/examples/taskrunner/Byggfile.yml
+++ b/examples/taskrunner/Byggfile.yml
@@ -6,14 +6,15 @@ actions:
     message: "I touched a file"
     shell: "touch foo"
     dependencies: ["ls", "do something more"]
-    is_entrypoint: true
 
   - name: "ls"
+    is_entrypoint: false
     shell: "ls -hal"
 
   - name: "do something more"
+    is_entrypoint: false
     message: "I did something more"
     shell: |
-        echo "foo"
-        ls -hal ..
-        echo "bar"
+      echo "foo"
+      ls -hal ..
+      echo "bar"


### PR DESCRIPTION
Actions in Byggfile.yml were made entrypoints by default in e65ae84ff7a248c5660d040057bfb7fe6119dcac .

This commit adjusts the actions in various Byggfile.yml files in examples/ so that the previous non-entrypoints revert back to that state. It also removes unneeded `is_entrypoint: true` declarations.