### PR TITLE
Improve argument unparsing and command line reconstruction

### DIFF
--- a/src/bygg/argument_unparsing.py
+++ b/src/bygg/argument_unparsing.py
@@ -1,0 +1,69 @@
+import argparse
+import functools
+from typing import List
+
+
+@functools.cache
+def _build_dest_to_action(parser: argparse.ArgumentParser) -> dict:
+    actions = parser._get_optional_actions() + parser._get_positional_actions()
+    dest_to_action = {action.dest: action for action in actions}
+    return dest_to_action
+
+
+def _get_argument_for_dest(parser: argparse.ArgumentParser, dest: str) -> str | None:
+    dest_to_action: dict[str, argparse.Action] = _build_dest_to_action(parser)
+    action = dest_to_action.get(dest, None)
+    if action is None:
+        return None
+    option_strings = action.option_strings
+    return option_strings[-1] if option_strings else ""
+
+
+def unparse_args(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+    *,
+    drop: List[str] | None = None,
+) -> List[str]:
+    """
+    Convert an argparse.Namespace back to a list of command line arguments.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The parser that was used to parse the command line arguments.
+    args : argparse.Namespace
+        The parsed command line arguments to unparse.
+    drop : List[str] | None, optional
+        Which dest keys to drop, by default None.
+
+    Returns
+    -------
+    List[str]
+        A list of command line arguments
+    """
+    exec_list = []
+    for k, v in vars(args).items():
+        argument = _get_argument_for_dest(parser, k)
+        if drop and k in drop:
+            continue
+        if v is False or v is None:
+            # These are arguments that were not given
+            continue
+        if v is True:
+            exec_list.append(argument)
+        elif v:
+            if argument:
+                exec_list.append(
+                    f"{argument}={','.join(v) if isinstance(v, (list, tuple)) else v}"
+                )
+            elif isinstance(v, (list, tuple)):
+                exec_list.extend(v)
+            else:
+                assert False
+        elif argument == "":
+            continue
+        else:
+            # Could happen if we add another type of argument
+            assert False
+    return exec_list

--- a/tests/test_argument_unparsing.py
+++ b/tests/test_argument_unparsing.py
@@ -1,0 +1,46 @@
+from bygg.argument_unparsing import unparse_args
+from bygg.main import create_argument_parser
+import pytest
+
+args = [
+    (["-v"], ["--version"]),
+    (["--version"], ["--version"]),
+    (["--clean"], ["--clean"]),
+    (["-l"], ["--list"]),
+    (["--list"], ["--list"]),
+    (["--tree"], ["--tree"]),
+    (["-B"], ["--always-make"]),
+    (["--always-make"], ["--always-make"]),
+    (["-C", "foo/bar"], ["--directory=foo/bar"]),
+    # more complex
+    (["-C", "foo/bar", "-l"], ["--directory=foo/bar", "--list"]),
+    (
+        ["-C", "foo/bar", "action1", "-B"],
+        ["--directory=foo/bar", "action1", "--always-make"],
+    ),
+]
+
+
+@pytest.mark.parametrize("arg", args, ids=lambda x: " ".join(x[0]))
+def test_unparse_args(arg):
+    in_arg, out_arg = arg
+    parser = create_argument_parser()
+    parsed_args = parser.parse_args(in_arg)
+    assert sorted(unparse_args(parser, parsed_args)) == sorted(out_arg)
+
+
+def test_unparse_args_drop():
+    parser = create_argument_parser()
+    parsed_args = parser.parse_args(["-C", "foo/bar", "action1", "-B"])
+    assert sorted(unparse_args(parser, parsed_args, drop=["directory"])) == sorted(
+        ["action1", "--always-make"]
+    )
+    assert sorted(unparse_args(parser, parsed_args, drop=["always_make"])) == sorted(
+        ["--directory=foo/bar", "action1"]
+    )
+    assert sorted(unparse_args(parser, parsed_args, drop=["actions"])) == sorted(
+        ["--directory=foo/bar", "--always-make"]
+    )
+    assert sorted(
+        unparse_args(parser, parsed_args, drop=["actions", "always_make", "directory"])
+    ) == sorted([])


### PR DESCRIPTION
Replace the rudimentary construction of the command line arguments used for starting child processes in separate environments with more robust functionality.

- Look up the parsed arguments in the argparse.ArgumentParser object that was used to parse the command line.
- Use the argparse.Action data to reconstruct the command line arguments.

Also put the code in its own file and add tests.