### PR TITLE
Add functions for running subprocesses connected to a tty

### DIFF
--- a/src/bygg/system_helpers.py
+++ b/src/bygg/system_helpers.py
@@ -1,0 +1,172 @@
+"""
+System-near helper functions. Only import things from the standard library here; this
+way these helpers can be used also for utility scripts.
+"""
+
+import errno
+import os
+import pty
+import shlex
+import signal
+import subprocess
+from typing import Generator
+
+
+class ProcessGenerator:
+    """
+    Class that wraps a process return value and a generator that yields the output of a
+    process line by line.
+
+    Attributes
+    ----------
+    returncode : int
+        Process return code.
+    generator : Generator
+        Generator that yields the output of the process line by line.
+
+    Yields
+    ------
+    str
+        Output of the process.
+    """
+
+    returncode: int
+    """Process return code."""
+
+    generator: Generator
+    """Generator that yields the output of the process line by line."""
+
+    def __init__(self):
+        self.returncode = -1
+
+    def __iter__(self):
+        self.value = yield from self.generator
+
+
+def subprocess_tty(cmd, encoding="utf-8", timeout=10, **kwargs):
+    """
+    Wrapper around subprocess.Popen that sets up the process as if it were running in a
+    TTY and returns a generator that yields the stdout of the process line by line.
+
+    Parameters
+    ----------
+    cmd :
+        Passed directly to subprocess.Popen; see its documentation for details.
+    encoding : str, optional
+        Encoding to use when reading stdout, by default "utf-8".
+    timeout : int, optional
+        Timeout to use when polling the child process to see if it has exited, by
+        default 10 seconds.
+
+    Returns
+    -------
+    ProcessGenerator
+        Generator that yields the stdout of the child process line by line. After the
+        generator is exhausted, the returncode attribute of the generator will be set to
+        the exit code of the child process.
+
+    Yields
+    ------
+    str
+        Lines of stdout from the child process.
+
+    Raises
+    ------
+    subprocess.TimeoutExpired
+        Re-raised if the child process did not exit within the set timeout after having
+        received both terminate and kill signals.
+
+    Can also raise other exceptions from subprocess.Popen.
+    """
+
+    generator = ProcessGenerator()
+
+    def subprocess_iterator():
+        # From https://stackoverflow.com/a/77387332
+        m, s = pty.openpty()
+        p = subprocess.Popen(cmd, stdout=s, stderr=s, **kwargs)
+        os.close(s)
+
+        try:
+            for line in open(m, encoding=encoding):
+                if not line:  # EOF
+                    break
+                yield line
+        except OSError as e:
+            if e.errno != errno.EIO:  # EIO also means EOF
+                raise
+        finally:
+            if p.poll() is None:
+                p.send_signal(signal.SIGINT)
+                try:
+                    p.wait(timeout)
+                except subprocess.TimeoutExpired:
+                    p.terminate()
+                    try:
+                        p.wait(timeout)
+                    except subprocess.TimeoutExpired:
+                        p.kill()
+                        raise
+            p.wait()
+            generator.returncode = p.returncode
+
+    generator.generator = subprocess_iterator()
+    return generator
+
+
+def subprocess_tty_print(cmd, encoding="utf-8", timeout=10, **kwargs):
+    """
+    Thin wrapper around subprocess_tty that prints its output line by line. See
+    subprocess_tty for details.
+
+
+    Parameters
+    ----------
+    See subprocess_tty.
+
+    Returns
+    -------
+    int
+        The status code from the subprocess.
+    """
+    proc = subprocess_tty(cmd, encoding, timeout, **kwargs)
+    for line in proc:
+        print(line.rstrip())
+    return proc.returncode
+
+
+class ExitCode(int):
+    """
+    An int with a customised __bool__ method that considers 0 to be truthy. This is
+    useful for working with subprocess return codes.
+    """
+
+    def __bool__(self):
+        return self == 0
+
+
+def call(cmd, encoding="utf-8", timeout=10, **kwargs) -> ExitCode:
+    """
+    Convenience wrapper around subprocess_tty_print; the command to be executed can be
+    given as string that will be split instead of as an array. Output will be printed
+    line by line.
+
+    Parameters
+    ----------
+    cmd : str
+        The command to be executed. Will be run through shlex.split().
+
+    See subprocess_tty_print and subprocess_tty for the other parameters.
+
+    Returns
+    -------
+    ExitCode
+        The exit code from the subprocess. ExitCode is a subclass of int that can be
+        used as a boolean; subprocess success (0) is considered truthy.
+
+    Raises
+    ------
+    See subprocess_tty_print and subprocess_tty.
+    """
+
+    return ExitCode(subprocess_tty_print(shlex.split(cmd), encoding, timeout, **kwargs))

--- a/tests/__snapshots__/test_system_helpers.ambr
+++ b/tests/__snapshots__/test_system_helpers.ambr
@@ -1,0 +1,17 @@
+# serializer version: 1
+# name: test_call
+  '''
+  foo
+  bar
+  baz
+  
+  '''
+# ---
+# name: test_subprocess_tty_print
+  '''
+  'foo
+  bar
+  baz'
+  
+  '''
+# ---

--- a/tests/test_system_helpers.py
+++ b/tests/test_system_helpers.py
@@ -1,0 +1,51 @@
+from bygg.system_helpers import ExitCode, call, subprocess_tty, subprocess_tty_print
+import pytest
+
+
+def test_ExitCode():
+    # Behaviour as a bool (inverted):
+    assert ExitCode(0)
+    assert not ExitCode(1)
+    assert bool(ExitCode(0)) is True
+    assert bool(ExitCode(1)) is False
+    # Behaviour as an int:
+    assert ExitCode(0) == 0
+    assert ExitCode(0) != 1
+    assert ExitCode(1) == 1
+    assert ExitCode(1) != 0
+    assert ExitCode(0) + 3 == 3
+    assert ExitCode(1) + 3 == 4
+    assert 3 + ExitCode(0) == 3
+    assert 3 + ExitCode(1) == 4
+    assert ExitCode(0) + ExitCode(0) == 0
+    assert ExitCode(3) + ExitCode(2) == 5
+    assert ExitCode(0) - ExitCode(0) == 0
+    assert ExitCode(3) - ExitCode(2) == 1
+    assert ExitCode(0) * ExitCode(0) == 0
+    assert ExitCode(3) * ExitCode(2) == 6
+    assert ExitCode(3) / ExitCode(2) == 1.5
+    assert ExitCode(8) / ExitCode(-4) == -2
+
+    with pytest.raises(ZeroDivisionError):
+        assert ExitCode(0) / ExitCode(0) == 0
+
+
+shell_command = "echo 'foo\nbar\nbaz'"
+
+
+def test_call(capsys, snapshot):
+    call(shell_command)
+    captured = capsys.readouterr()
+    assert captured.out == snapshot
+
+
+def test_subprocess_tty_print(capsys, snapshot):
+    subprocess_tty_print(shell_command.split(" "))
+    captured = capsys.readouterr()
+    assert captured.out == snapshot
+
+
+def test_subprocess_tty():
+    words = shell_command.split(" ")[-1].split("\n")
+    for line, word in zip(subprocess_tty(shell_command.split(" ")), words):
+        assert line.rstrip() == word


### PR DESCRIPTION
The subprocess module in the Python standard library does not have a convenient way of getting the output of a subprocess as it is produced. Having this ability is useful both for displaying the output of a subprocess in real time, as well as for adding metadata like timestamps to the output line by line.

Add subprocess_tty, a function for running subprocesses connected to a tty. The function returns a generator object that yields the output of the subprocess line by line as it is produced. After the generator has been exhausted, the object's returncode attribute contains the returncode of the subprocess. With credit to
https://stackoverflow.com/a/77387332 .

Add a convenience function, subprocess_tty_print, for calling a process and print out the output as it is produced.

Add another convenience function, call, that works like the former but in addition returns a customised int whose boolean value is True if the subprocess returned a zero exit code, and False otherwise. Intended for use e.g. when using Python for shell scripting.