### PR TITLE
Only try to partition Byggfile.yml actions if there are any

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ def examples(session):
 
     with session.chdir("examples/trivial"):
         session.run("bygg")
+        session.run("bygg", "transform")
         session.run("bygg", "--tree")
         session.run("bygg", "--clean")
 

--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -305,7 +305,9 @@ def dispatcher():
         list_actions_and_exit(ctx, configuration)
 
     try:
-        action_partitions = partition_actions(configuration, args.actions)
+        action_partitions = (
+            partition_actions(configuration, args.actions) if configuration else None
+        )
     except KeyError as e:
         output_plain(
             f"Could not find action {TS.BOLD}{e}{TS.RESET}. List available actions with {TS.BOLD}--list{TS.RESET}."
@@ -384,7 +386,7 @@ class ActionPartition:
 
 
 def partition_actions(
-    configuration: ByggFile | None,
+    configuration: ByggFile,
     actions: List[str] | None,
 ) -> List[ActionPartition] | None:
     """
@@ -392,12 +394,12 @@ def partition_actions(
     """
     resolved_actions = actions if actions else []
 
-    if configuration:
-        if not actions and configuration.settings.default_action is not None:
-            # Resolve to default action:
-            resolved_actions += [configuration.settings.default_action]
-            return [ActionPartition("default", resolved_actions)]
+    if not actions and configuration.settings.default_action is not None:
+        # Resolve to default action:
+        resolved_actions += [configuration.settings.default_action]
+        return [ActionPartition("default", resolved_actions)]
 
+    if configuration.actions:
         # Put consecutive actions with the same environment in the same partition:
         action_partitions = []
         action_dict = {a.name: a for a in configuration.actions}


### PR DESCRIPTION
Building the transform action from examples/trivial would fail with a "Could not find action" error, but building the same action as the default action would work.

This was due to the partitioning code trying to partition the empty list of actions from Byggfile.yml when there was an action given on the command line, and this would fail.

The default action case would succeed because
examples/trivial/Byggfile.yml has a default action declared.

Fix this in the partitioning code so that Byggfile.py will be evaluated.

Also add a test case to noxfile.py.