### PR TITLE
Cleanup and fixes to entrypoints and dispatching

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ def examples(session):
     session.install(".")
 
     with session.chdir("examples/only_python"):
-        session.run("bygg")
+        session.run("bygg", success_codes=[1])
         session.run("bygg", "hello")
         session.run("bygg", "hello", "--tree")
         session.run("bygg", "--clean")

--- a/src/bygg/configuration.py
+++ b/src/bygg/configuration.py
@@ -11,7 +11,7 @@ PYTHON_INPUTFILE = "Byggfile.py"
 YAML_INPUTFILE = "Byggfile.yml"
 
 
-class SettingsSection(msgspec.Struct, forbid_unknown_fields=True):
+class Settings(msgspec.Struct, forbid_unknown_fields=True):
     default_action: Optional[str] = None
 
 
@@ -69,13 +69,13 @@ class Environment(msgspec.Struct, forbid_unknown_fields=True):
 
 class ByggFile(msgspec.Struct, forbid_unknown_fields=True):
     actions: List[ActionItem]
-    settings: SettingsSection = msgspec.field(default_factory=SettingsSection)
+    settings: Settings = msgspec.field(default_factory=Settings)
     environments: Dict[str, Environment] = msgspec.field(default_factory=dict)
 
 
-def read_config_file() -> ByggFile | None:
+def read_config_file() -> ByggFile:
     if not os.path.isfile(YAML_INPUTFILE):
-        return None
+        return ByggFile(actions=[], settings=Settings(), environments={})
 
     try:
         with open(YAML_INPUTFILE, "r") as f:

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -15,7 +15,7 @@
             }
           },
           "settings": {
-            "$ref": "#/$defs/SettingsSection"
+            "$ref": "#/$defs/Settings"
           },
           "environments": {
             "type": "object",
@@ -141,8 +141,8 @@
         ],
         "additionalProperties": false
       },
-      "SettingsSection": {
-        "title": "SettingsSection",
+      "Settings": {
+        "title": "Settings",
         "type": "object",
         "properties": {
           "default_action": {
@@ -312,8 +312,11 @@
 # ---
 # name: test_list[trivial]
   '''
-  Loaded build files but no entrypoints were found.
-  Type `bygg --help` for help.
+  Available actions:
+  
+  transform (default)
+      No description
+  
   
   '''
 # ---
@@ -420,8 +423,11 @@
 # name: test_list_directory[trivial]
   '''
   🛈 Entering directory 'examples/trivial'
-  Loaded build files but no entrypoints were found.
-  Type `bygg --help` for help.
+  Available actions:
+  
+  transform (default)
+      No description
+  
   
   '''
 # ---
@@ -460,6 +466,8 @@
 # ---
 # name: test_tree[only_python]
   '''
+  No actions specified and no default action is defined.
+  
   Available actions:
   
   hello
@@ -835,6 +843,8 @@
 # name: test_tree_directory[only_python]
   '''
   🛈 Entering directory 'examples/only_python'
+  No actions specified and no default action is defined.
+  
   Available actions:
   
   hello

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,17 +9,17 @@ import pytest
 class ExampleParameters:
     name: str
     list_rc: int = 0
+    tree_rc: int = 0
 
 
-# TODO exceptions below indicate missing functionality
 examples = [
     ExampleParameters("checks"),
     ExampleParameters("environments"),
     ExampleParameters("failing_jobs"),
-    ExampleParameters("only_python"),  # TODO: should have list_rc=1
+    ExampleParameters("only_python", tree_rc=1),
     ExampleParameters("parametric"),
     ExampleParameters("taskrunner"),
-    ExampleParameters("trivial", list_rc=1),  # TODO: should have list_rc=0
+    ExampleParameters("trivial"),
 ]
 
 examples_dir = Path("examples")
@@ -57,7 +57,7 @@ def test_tree(snapshot, clean_bygg_tree, example):
         capture_output=True,
         encoding="utf-8",
     )
-    assert process.returncode == 0
+    assert process.returncode == example.tree_rc
     assert process.stdout == snapshot
 
 
@@ -69,7 +69,7 @@ def test_tree_directory(snapshot, clean_bygg_tree, example):
         capture_output=True,
         encoding="utf-8",
     )
-    assert process.returncode == 0
+    assert process.returncode == example.tree_rc
     assert process.stdout == snapshot
 
 


### PR DESCRIPTION
Correct the behaviour of default actions, including with the --list and --tree
arguments. These would not work in all combinations of having a default target
set and actions declared in YAML or Python.

Details:

dispatcher cleanup and bug fixes:

Resolve correctly to the default action declared in Byggfile.yml when loading
the actual actions from a Python file.

Make the handling of --list and --tree clearer and make them work correctly.

get_entrypoints:

Have get_entrypoints return entrypoints from the configuration if the scheduler
has not yet been initialised. This happens when environments in addition to the
default environment have been configured in the configuration file. In this
case, all entrypoints must currently be declared in the configuration file
(this constraint is not new from this commit).

Also add a small abstraction to have it only return the names and descriptions
of the actions.

Other cleanup:

- Rename the SettingsSection class to Settings.
- Create a default Settings structure if there is no settings file.
- Include the Settings structure in ByggContext.
- Simplify code that can now assume that ByggContext.configuration always
  exists.
- Adapt entrypoint_completions accordingly.
