### PR TITLE
Move the --tree argument to the build setup group

### DIFF
--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -514,6 +514,11 @@ List available actions:
         action="store_true",
         help="List available actions.",
     )
+    build_setup_group.add_argument(
+        "--tree",
+        action="store_true",
+        help="Display the dependency tree starting from the specified action(s).",
+    )
     # Some arguments inspired by Make:
     make_group = parser.add_argument_group("Make-like arguments")
     make_group.add_argument(
@@ -548,11 +553,6 @@ List available actions:
         "--check",
         action="store_true",
         help="Perform various checks on the action tree. Implies -B",
-    )
-    analyse_group.add_argument(
-        "--tree",
-        action="store_true",
-        help="Display the dependency tree starting from the specified action(s).",
     )
 
     # Meta arguments:


### PR DESCRIPTION
The --tree argument is more like --list than it is like the ones in the analyse group, so move it to the build setup group. This way, it can also be made mutually exclusive with --list and --clean.