### PR TITLE
Action description fixes

### DIFF
--- a/examples/only_python/Byggfile.py
+++ b/examples/only_python/Byggfile.py
@@ -1,10 +1,18 @@
-from bygg.action import Action, ActionContext
+from bygg.action import Action, ActionContext, action
 from bygg.common_types import CommandStatus
 
 
 def hello(ctx: ActionContext):
+    """An action that says 'Hello'."""
     print("Hello")
     return CommandStatus(0, "And goodbye.", None)
 
 
 Action("hello", command=hello, is_entrypoint=True)
+
+
+@action("hi", is_entrypoint=True)
+def hi(ctx: ActionContext):
+    """An action that says 'Hi'."""
+    print("Hi")
+    return CommandStatus(0, "And goodbye.", None)

--- a/src/bygg/action.py
+++ b/src/bygg/action.py
@@ -55,7 +55,6 @@ class Action(ActionContext):
     def __init__(
         self,
         name: str,
-        description: str | None = None,
         message: str | None = None,
         inputs: Optional[Iterable[str]] = None,
         outputs: Optional[Iterable[str]] = None,
@@ -64,9 +63,9 @@ class Action(ActionContext):
         is_entrypoint: bool = False,
         command: Command | None = None,
         scheduling_type: SchedulingType = "processpool",
+        description: str | None = None,
     ):
         self.name = name
-        self.description = description
         self.message = message
         self.inputs = {*inputs} if inputs else set()
         self.outputs = {*outputs} if outputs else set()
@@ -75,6 +74,7 @@ class Action(ActionContext):
         self.is_entrypoint = is_entrypoint
         self.command = command
         self.scheduling_type = scheduling_type
+        self.description = description if description else command.__doc__
 
         self.dependency_files = set()
 
@@ -107,7 +107,7 @@ def action(
     def create_action(func: Callable):
         Action(
             name,
-            message,
+            message=message,
             inputs=inputs,
             outputs=outputs,
             dependencies=dependencies,

--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -74,16 +74,19 @@
 # name: test_actions_completions[only_python]
   list([
     'hello',
+    'hi',
   ])
 # ---
 # name: test_actions_completions[only_python].1
   list([
     'hello',
+    'hi',
   ])
 # ---
 # name: test_actions_completions[only_python].2
   list([
     'hello',
+    'hi',
   ])
 # ---
 # name: test_actions_completions[parametric]

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -282,7 +282,10 @@
   Available actions:
   
   hello
-      No description
+      An action that says 'Hello'.
+  
+  hi
+      An action that says 'Hi'.
   
   
   '''
@@ -390,7 +393,10 @@
   Available actions:
   
   hello
-      No description
+      An action that says 'Hello'.
+  
+  hi
+      An action that says 'Hi'.
   
   
   '''
@@ -471,7 +477,10 @@
   Available actions:
   
   hello
-      No description
+      An action that says 'Hello'.
+  
+  hi
+      An action that says 'Hi'.
   
   
   '''
@@ -848,7 +857,10 @@
   Available actions:
   
   hello
-      No description
+      An action that says 'Hello'.
+  
+  hi
+      An action that says 'Hi'.
   
   
   '''


### PR DESCRIPTION
- Fetch the description for an action from the action function's __doc__
  if present. It is still possible to add a description in the
  constructor, and this takes precedence.
- Fix a bug in the action decorator where the description would be used
  as the message.
- Add a decorator-declared action to the only_python example.