### PR TITLE
Add change_dir context manager

### DIFF
--- a/src/bygg/system_helpers.py
+++ b/src/bygg/system_helpers.py
@@ -3,6 +3,7 @@ System-near helper functions. Only import things from the standard library here;
 way these helpers can be used also for utility scripts.
 """
 
+import contextlib
 import errno
 import os
 import pty
@@ -170,3 +171,14 @@ def call(cmd, encoding="utf-8", timeout=10, **kwargs) -> ExitCode:
     """
 
     return ExitCode(subprocess_tty_print(shlex.split(cmd), encoding, timeout, **kwargs))
+
+
+@contextlib.contextmanager
+def change_dir(dir: str | os.PathLike | None):
+    old_dir = os.getcwd()
+    try:
+        if dir is not None:
+            os.chdir(dir)
+        yield
+    finally:
+        os.chdir(old_dir)

--- a/tests/test_system_helpers.py
+++ b/tests/test_system_helpers.py
@@ -1,4 +1,12 @@
-from bygg.system_helpers import ExitCode, call, subprocess_tty, subprocess_tty_print
+import os
+
+from bygg.system_helpers import (
+    ExitCode,
+    call,
+    change_dir,
+    subprocess_tty,
+    subprocess_tty_print,
+)
 import pytest
 
 
@@ -49,3 +57,26 @@ def test_subprocess_tty():
     words = shell_command.split(" ")[-1].split("\n")
     for line, word in zip(subprocess_tty(shell_command.split(" ")), words):
         assert line.rstrip() == word
+
+
+def test_change_dir():
+    start_dir = os.getcwd()
+    with change_dir("/"):
+        assert os.getcwd() == "/"
+    assert os.getcwd() == start_dir
+
+    with change_dir("examples"):
+        assert os.getcwd() == os.path.join(start_dir, "examples")
+    assert os.getcwd() == start_dir
+
+    with change_dir("examples/checks"):
+        assert os.getcwd() == os.path.join(start_dir, "examples/checks")
+    assert os.getcwd() == start_dir
+
+    with change_dir("examples/trivial"):
+        assert os.getcwd() == os.path.join(start_dir, "examples/trivial")
+    assert os.getcwd() == start_dir
+
+    with change_dir(None):
+        assert os.getcwd() == start_dir
+    assert os.getcwd() == start_dir


### PR DESCRIPTION
Useful for executing a block of code in a certain directory and changing back to the original directory afterwards.