### PR TITLE
Resolve preamble module load path

### DIFF
--- a/src/bygg/apply_configuration.py
+++ b/src/bygg/apply_configuration.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import textwrap
 from typing import List
 
 from bygg.action import Action
@@ -130,8 +131,14 @@ def apply_configuration(
 
 
 def load_python_build_file(build_file: str):
+    # modify load path to make the current directory importable
+    preamble = """\
+        import os
+        import sys
+        sys.path.insert(0, str(os.path.realpath('.')))
+
+        """
+
     if os.path.isfile(build_file):
         with open(build_file, "r") as f:
-            # modify load path to make the current directory importable
-            preamble = "import sys\nsys.path.insert(0, '.')\n\n"
-            exec(preamble + f.read(), globals())
+            exec(textwrap.dedent(preamble) + f.read(), globals())


### PR DESCRIPTION
Resolve the module load path that is inserted into the preamble to the Python Byggfiles. This makes the paths work reliably even when they're symlinked.

This solves the test failures that have started occurring in the GitHub Actions in CI, but should also be a general improvement.

Also break out the preamble to a multiline string for improved readability.