### PR TITLE
Correct typing of Dag.__len__

### DIFF
--- a/src/bygg/dag.py
+++ b/src/bygg/dag.py
@@ -6,7 +6,7 @@ from bygg.action import Action
 
 
 class Dag(metaclass=ABCMeta):
-    def __len__(self):
+    def __len__(self) -> int:
         return 0
 
     def clear(self):


### PR DESCRIPTION
Discovered when upgrading pyright.