### PR TITLE
Add macos-14 to the code-quality workflow

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python_version: ["3.11", "3.12"]
         nox_session: [tests, basics, examples]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-14]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pipx install nox
+          pip install nox
       - name: Test with nox
         run: |
           nox --python ${{ matrix.python_version }} --session ${{ matrix.nox_session }}


### PR DESCRIPTION
Have the nox testing in the code-quality workflow run also on macos-14, which is GitHub's ARM macOS runners.

pipx is currently not able to install nox on these runners, so use pip instead.