### PR TITLE
Use uv

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -13,6 +13,7 @@ jobs:
         python_version: ["3.11", "3.12"]
         nox_session: [tests, basics, examples]
         os: [ubuntu-latest, macos-latest, macos-14]
+        install_uv: [0, 1]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -25,9 +26,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install nox
+          if [ ${{ matrix.install_uv }} -eq 1 ]; then
+            pip install uv
+          fi
       - name: Test with nox
         run: |
-          nox --python ${{ matrix.python_version }} --session ${{ matrix.nox_session }}
+          nox --python ${{ matrix.python_version }} --session ${{ matrix.nox_session }} -db ${{ matrix.install_uv == 1 && 'uv' || 'virtualenv' }}
 
   pyright_and_ruff:
     strategy:

--- a/examples/environments/Byggfile.yml
+++ b/examples/environments/Byggfile.yml
@@ -32,9 +32,15 @@ environments:
       - "requirements1.txt"
     venv_directory: .venv1
     shell: |
-      python3 -m venv .venv1
-      .venv1/bin/pip install -r requirements1.txt
-      .venv1/bin/pip install -e ../../
+      if command -v uv > /dev/null 2>&1; then
+        uv venv .venv1
+        VIRTUAL_ENV=.venv1 uv pip install -r requirements1.txt
+        VIRTUAL_ENV=.venv1 uv pip install -e ../../
+      else
+        python3 -m venv .venv1
+        .venv1/bin/pip install -r requirements1.txt
+        .venv1/bin/pip install -e ../../
+      fi
 
   env2:
     byggfile: "Byggfile2.py"
@@ -42,9 +48,15 @@ environments:
       - "requirements2.txt"
     venv_directory: .venv2
     shell: |
-      python3 -m venv .venv2
-      .venv2/bin/pip install -r requirements2.txt
-      .venv2/bin/pip install -e ../../
+      if command -v uv > /dev/null 2>&1; then
+        uv venv .venv2
+        VIRTUAL_ENV=.venv2 uv pip install -r requirements2.txt
+        VIRTUAL_ENV=.venv2 uv pip install -e ../../
+      else
+        python3 -m venv .venv2
+        .venv2/bin/pip install -r requirements2.txt
+        .venv2/bin/pip install -e ../../
+      fi
 
   default:
     byggfile: "Byggfile.py"
@@ -52,6 +64,12 @@ environments:
       - requirements.txt
     venv_directory: .venv
     shell: |
-      python3 -m venv .venv
-      .venv/bin/pip install -r requirements.txt
-      .venv/bin/pip install -e ../../
+      if command -v uv > /dev/null 2>&1; then
+        uv venv .venv
+        VIRTUAL_ENV=.venv uv pip install -r requirements.txt
+        VIRTUAL_ENV=.venv uv pip install -e ../../
+      else
+        python3 -m venv .venv
+        .venv/bin/pip install -r requirements.txt
+        .venv/bin/pip install -e ../../
+      fi


### PR DESCRIPTION
## Run GitHub nox workflow step with and without uv.

## Use uv in the environments example
If uv is installed, use it instead of pip to create and set up
environments in the environments example. This shortens the run time,
which is especially noticeable when running in pytest and nox.