### PR TITLE
Test directory completions in examples

### DIFF
--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -139,23 +139,23 @@
 # ---
 # name: test_directory_completions[--directory ]
   list([
-    'examples/checks',
-    'examples/environments',
-    'examples/failing_jobs',
-    'examples/only_python',
-    'examples/parametric',
-    'examples/taskrunner',
-    'examples/trivial',
+    'checks',
+    'environments',
+    'failing_jobs',
+    'only_python',
+    'parametric',
+    'taskrunner',
+    'trivial',
   ])
 # ---
 # name: test_directory_completions[-C ]
   list([
-    'examples/checks',
-    'examples/environments',
-    'examples/failing_jobs',
-    'examples/only_python',
-    'examples/parametric',
-    'examples/taskrunner',
-    'examples/trivial',
+    'checks',
+    'environments',
+    'failing_jobs',
+    'only_python',
+    'parametric',
+    'taskrunner',
+    'trivial',
   ])
 # ---

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -73,7 +73,8 @@ directories_completions = [
 
 
 @pytest.mark.parametrize("arg", directories_completions, ids=lambda x: x)
-def test_directory_completions(completion_tester, arg, snapshot):
+def test_directory_completions(completion_tester, arg, snapshot, monkeypatch):
+    monkeypatch.chdir("examples")
     testcase = arg
     testresult = completion_tester(testcase)
     assert sorted(testresult.split("\x0b")) == snapshot


### PR DESCRIPTION
Use monkeypatch to chdir to the examples directory when testing directory completions. This makes the test more stable if directories with other Byggfiles are added in the source tree, e.g. for templating.