### PR TITLE
Add tests for digest functionality and fix a bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ include = ["src/bygg", "tests"]
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib", "tests/"]
+markers = ["digest: Tests for digest functionality."]
 
 [tool.ruff]
 exclude = ["_version.py"]

--- a/src/bygg/core/digest.py
+++ b/src/bygg/core/digest.py
@@ -41,14 +41,9 @@ def calculate_dependency_digest(filenames: set[str]) -> tuple[str, bool]:
     Returns: The digest of the files as a hex string.
     """
 
-    files_were_missing = False
-
-    digests = sorted(
-        filter(None, [calculate_file_digest(filename) for filename in filenames])
-    )
-
-    # if len(digests) == 0:
-    #     return ""
+    file_digests = [calculate_file_digest(filename) for filename in filenames]
+    digests = sorted(filter(None, file_digests))
+    files_were_missing = len(file_digests) != len(digests)
 
     return (
         hashlib.new(DIGEST_TYPE, "".join(digests).encode()).hexdigest(),

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,0 +1,83 @@
+from bygg.core.digest import calculate_dependency_digest, calculate_file_digest
+import pytest
+
+pytestmark = pytest.mark.digest
+
+
+def test_calculate_file_digest_existing(tmp_path):
+    filenames = ["file1", "file2", "file3"]
+
+    for filename in filenames:
+        file = tmp_path / filename
+        file.write_text(f"content for {filename}")
+
+    digests1 = set(
+        calculate_file_digest(str(tmp_path / filename)) for filename in filenames
+    )
+    assert all(digests1)
+
+    digests2 = set(
+        calculate_file_digest(str(tmp_path / filename)) for filename in filenames
+    )
+
+    assert digests1 == digests2
+
+
+def test_calculate_file_digest_non_existing(tmp_path):
+    filenames = ["file1", "file2", "file3"]
+
+    digests1 = set(
+        calculate_file_digest(str(tmp_path / filename)) for filename in filenames
+    )
+    assert map(lambda x: x is None, digests1)
+
+    digests2 = set(
+        calculate_file_digest(str(tmp_path / filename)) for filename in filenames
+    )
+
+    assert map(lambda x: x is None, digests2)
+
+
+def test_calculate_dependency_digest_existing(tmp_path):
+    files = set(tmp_path / filename for filename in ["file1", "file2", "file3"])
+
+    for file in files:
+        file.write_text(f"content for {str(file)}")
+
+    digests1, was_missing1 = calculate_dependency_digest(
+        set(str(file) for file in files)
+    )
+
+    assert digests1
+    assert not was_missing1
+
+    digests2, was_missing2 = calculate_dependency_digest(
+        set(str(file) for file in files)
+    )
+
+    assert digests1 == digests2
+    assert not was_missing2
+
+
+def test_calculate_dependency_digest_non_existing(tmp_path):
+    files = list(tmp_path / filename for filename in ["file1", "file2", "file3"])
+
+    for file in files:
+        file.write_text(f"content for {str(file)}")
+
+    digests1, was_missing1 = calculate_dependency_digest(
+        set(str(file) for file in files)
+    )
+
+    assert digests1
+    assert not was_missing1
+
+    filenames = set(str(file) for file in files)
+    unlinked_file = files.pop()
+    unlinked_file.unlink()
+
+    digests2, was_missing2 = calculate_dependency_digest(filenames)
+
+    assert len(digests2)
+    assert digests2 != digests1
+    assert was_missing2


### PR DESCRIPTION
- Add basic tests for the digest functionality.
- Fix calculate_dependency_digest so that it returns the correct status for missing files.

Closes #143.