### PR TITLE
Add scheduler test for changed input + bug fix

### DIFF
--- a/src/bygg/core/scheduler.py
+++ b/src/bygg/core/scheduler.py
@@ -77,8 +77,9 @@ class Scheduler:
             self.build_actions, self.build_actions[entrypoint]
         )
 
-        # Fill the actions' _dependency_files from their dependencies
+        # Fill the actions' dependency_files from self and their dependencies
         for action in self.build_actions.values():
+            action.dependency_files.update(action.inputs)
             for dependency in action.dependencies:
                 action.dependency_files.update(self.build_actions[dependency].outputs)
             # print(f"Action {action.name} inputs: {action._dependency_files}")


### PR DESCRIPTION
Add a scheduler test to check that changing the Action's input file causes a rebuild.

Fix a bug where a change to the Action's own inputs but only its dependencies would trigger a rebuild.