### PR TITLE
File digests work

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,6 +4,7 @@ pip==24.0
 pip-tools==7.4.1
 pyright==1.1.357
 pytest==8.1.1
+pytest-mock==3.14.0
 ruff==0.3.4
 setuptools==69.2.0
 syrupy==4.6.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -77,7 +77,12 @@ pyright==1.1.357 \
 pytest==8.1.1 \
     --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \
     --hash=sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044
-    # via syrupy
+    # via
+    #   pytest-mock
+    #   syrupy
+pytest-mock==3.14.0 \
+    --hash=sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f \
+    --hash=sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0
 ruff==0.3.4 \
     --hash=sha256:3f3860057590e810c7ffea75669bdc6927bfd91e29b4baa9258fd48b540a4365 \
     --hash=sha256:519cf6a0ebed244dce1dc8aecd3dc99add7a2ee15bb68cf19588bb5bf58e0488 \

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,4 +1,12 @@
-from bygg.core.digest import calculate_dependency_digest, calculate_file_digest
+import os
+from pathlib import Path
+import time
+
+from bygg.core.digest import (
+    calculate_dependency_digest,
+    calculate_file_digest,
+    file_digest_memo,
+)
 import pytest
 
 pytestmark = pytest.mark.digest
@@ -81,3 +89,116 @@ def test_calculate_dependency_digest_non_existing(tmp_path):
     assert len(digests2)
     assert digests2 != digests1
     assert was_missing2
+
+
+# Time to sleep after modifying file content that is different but has the same size.
+# Simulates that it's unlikely that different content with the same size is written at
+# the same time as the previous content that we digested.
+SETTLE_TIME = 1 / 1e2
+
+
+def test_file_digest_memo(tmp_path, mocker):
+    import bygg.core.digest
+
+    digest_spy = mocker.spy(bygg.core.digest, "file_digest")
+
+    file = tmp_path / "file"
+    filename = str(file)
+
+    # Initial run, should give cache miss.
+    expected_digest_calls = 1
+    file.write_text(f"content for {filename}")
+    st = os.stat(filename)
+    digest1 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest1
+    assert digest_spy.call_count == expected_digest_calls
+
+    # No content or stat change. Should give cache hit.
+    digest2 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest2 == digest1
+    assert digest_spy.call_count == expected_digest_calls
+
+    # Write the same content again. Should give cache miss.
+    expected_digest_calls += 1
+    time.sleep(SETTLE_TIME)
+    file.write_text(f"content for {filename}")
+    st = os.stat(filename)
+    digest3 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest3 == digest1
+    assert digest_spy.call_count == expected_digest_calls
+
+    # Again, no content or stat change. Should give cache hit.
+    digest4 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest4 == digest1
+    assert digest_spy.call_count == expected_digest_calls
+
+    # Write new content but with same size. Should give cache miss.
+    expected_digest_calls += 1
+    time.sleep(SETTLE_TIME)
+    file.write_text(f"content_for_{filename}")
+    st = os.stat(filename)
+    digest5 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest5 != digest1
+    assert digest_spy.call_count == expected_digest_calls
+
+    # Write new content with different size. Should give cache miss.
+    expected_digest_calls += 1
+    file.write_text(f"more content for {filename}")
+    st = os.stat(filename)
+    digest6 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest6 != digest1
+    assert digest_spy.call_count == expected_digest_calls
+
+    # Again, no content or stat change. Should give cache hit.
+    digest7 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest7 == digest6
+    assert digest_spy.call_count == expected_digest_calls
+
+    # No content or stat change. Should give cache hit.
+    digest8 = file_digest_memo(filename, st.st_ctime_ns, st.st_mtime_ns, st.st_size)
+
+    assert digest8 == digest6
+    assert digest_spy.call_count == expected_digest_calls
+
+
+def test_calculate_dependency_digest(tmp_path: Path, mocker):
+    file = tmp_path / "file"
+    filename = str(file)
+    file_set = set([filename])
+
+    # Initial run
+    file.write_text(f"content for {filename}")
+    digests1, was_missing1 = calculate_dependency_digest(file_set)
+
+    assert digests1
+    assert not was_missing1
+
+    # No content change
+    time.sleep(SETTLE_TIME)
+    file.write_text(f"content for {filename}")
+    digests2, was_missing2 = calculate_dependency_digest(file_set)
+
+    assert digests2 == digests1
+    assert not was_missing2
+
+    # Content change but no size change
+    time.sleep(SETTLE_TIME)
+    file.write_text(f"content_for_{filename}")
+    digests3, was_missing3 = calculate_dependency_digest(file_set)
+
+    assert digests3 != digests1
+    assert not was_missing3
+
+    # Content change with size change
+    file.write_text(f"more content for {filename}")
+    digests4, was_missing4 = calculate_dependency_digest(file_set)
+
+    assert digests4 != digests3
+    assert not was_missing4


### PR DESCRIPTION
- Memoize file_digest based not only on st_mtime_ns but also on st_ctime_ns and st_size.
- Add pytest-mock 3.14.0.
- Add tests for the file digest code using pytest-mock.
- Clean up the code a bit.