### PR TITLE
Collect entrypoints from all Python environments

### DIFF
--- a/examples/environments/Byggfile1.py
+++ b/examples/environments/Byggfile1.py
@@ -7,3 +7,10 @@ import rich
 def example_action(ctx: ActionContext):
     rich.print("[magenta]Running default action from Python.[/magenta]")
     return CommandStatus(0, "All ok.", None)
+
+
+@action("action1_python_entrypoint_python", is_entrypoint=True)
+def example_action_entrypoint(ctx: ActionContext):
+    """An entrypoint action declared in Python."""
+    rich.print("[magenta]Running entrypoint action from Python.[/magenta]")
+    return CommandStatus(0, "All ok.", None)

--- a/src/bygg/cmd/completions.py
+++ b/src/bygg/cmd/completions.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 from pathlib import Path
 import shutil
 import sys
@@ -106,6 +107,10 @@ class ByggCompletionFinder(CompletionFinder):
 def do_completion(parser: argparse.ArgumentParser):
     completer = ByggCompletionFinder()
     completer(parser)
+
+
+def is_completing():
+    return os.environ.get("_ARGCOMPLETE") == "1"
 
 
 def generate_shell_completions(print_and_exit: bool):

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -1,20 +1,18 @@
 import argparse
-from dataclasses import dataclass
 import os
 import subprocess
 import sys
+import tempfile
 from typing import Any
 
-from bygg.cmd.apply_configuration import (
-    apply_configuration,
-    register_actions_from_configuration,
-)
+from bygg.cmd.apply_configuration import apply_configuration
 from bygg.cmd.argument_unparsing import unparse_args
 from bygg.cmd.build_clean import build, clean
 from bygg.cmd.completions import (
     ByggfileDirectoriesCompleter,
     do_completion,
     generate_shell_completions,
+    is_completing,
 )
 from bygg.cmd.configuration import (
     PYTHON_INPUTFILE,
@@ -23,26 +21,22 @@ from bygg.cmd.configuration import (
     dump_schema,
     read_config_file,
 )
-from bygg.cmd.datastructures import ByggContext, get_entrypoints
-from bygg.cmd.list_actions import list_actions
-from bygg.cmd.tree import display_tree
+from bygg.cmd.datastructures import ByggContext, SubProcessIpcData
+from bygg.cmd.list_actions import list_actions, list_collect_subprocess, print_actions
+from bygg.cmd.tree import display_tree, print_tree
 from bygg.core.runner import ProcessRunner
 from bygg.core.scheduler import Scheduler
 from bygg.output.output import (
-    TerminalStyle as TS,
-)
-from bygg.output.output import (
     output_error,
     output_info,
-    output_plain,
     output_warning,
 )
 from bygg.output.status_display import (
     on_job_status,
     on_runner_status,
 )
-from bygg.system_helpers import change_dir
 from loguru import logger
+import msgspec
 
 
 def init_bygg_context(configuration: ByggFile):
@@ -64,16 +58,29 @@ def print_version():
 
 MAKE_COMPATIBLE_PANEL = "(Roughly) Make-compatible options"
 
+DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE = 127
+"""Exit code returned by a subprocess when an action is not found."""
 
-def dispatcher():
-    """
-    A build tool written in Python, where all actions can be written in Python.
-    """
+
+def bygg():
+    """Entry point for the Bygg command line interface."""
     parser = create_argument_parser()
-    do_completion(parser)
-
     args = parser.parse_args()
+    is_restarted_with_env = (
+        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
+    )
+    if is_restarted_with_env is None:
+        do_completion(parser)
+    return dispatcher(parser, args)
 
+
+def dispatcher(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> dict[str, SubProcessIpcData] | None:
+    """
+    Takes both argparse.ArgumentParser and argparse.Namespace arguments since it can be
+    called also from completers.
+    """
     generate_shell_completions(args.completions)
 
     if args.dump_schema:
@@ -101,86 +108,204 @@ def dispatcher():
     configuration = read_config_file()
     ctx = init_bygg_context(configuration)
 
-    try:
-        action_partitions = (
-            partition_actions(configuration, args.actions) if configuration else None
-        )
-    except KeyError as e:
-        output_plain(
-            f"Could not find action {TS.BOLD}{e}{TS.RESET}. List available actions with {TS.BOLD}--list{TS.RESET}."
-        )
-        sys.exit(1)
-
-    if not action_partitions:
-        if os.path.isfile(PYTHON_INPUTFILE):
-            # No configuration file, so load the Python build file directly.
+    if not configuration.environments:
+        if os.path.isfile(PYTHON_INPUTFILE) or os.path.isfile(YAML_INPUTFILE):
+            # No environments, so just load the Python build file directly.
             apply_configuration(configuration, None, None)
-            default_action = configuration.settings.default_action
-            actions = (
-                args.actions
-                if args.actions
-                else [default_action]
-                if default_action
-                else []
-            )
-            status = do_dispatch(ctx, args, actions)
+
+            # Gather and return actions if completing
+            if is_completing():
+                ctx.ipc_data = SubProcessIpcData()
+                list_collect_subprocess(ctx, args)
+                return {"default": ctx.ipc_data}
+
+            status = inner_dispatch(ctx, args)
         else:
-            status = list_actions(ctx)
+            status = list_actions(ctx, args)
 
         if status:
             sys.exit(0)
         sys.exit(1)
 
-    # Special case for --list here, since it shouldn't start loading the environments:
-    if args.list:
-        status = list_actions(ctx)
-        sys.exit(0) if status else sys.exit(1)
+    # Execute each action within the correct environment:
 
-    # Execute each action partition within the correct environment:
+    # Parent process
+    if not is_restarted_with_env:
+        subprocess_output: dict[str, SubProcessIpcData] = {}
+        actions: list[str | None] = (
+            args.actions
+            if len(args.actions) > 0
+            else [configuration.settings.default_action]
+        )
 
-    for partition in action_partitions:
-        env = partition.environment_name
+        for action in actions:
+            dispatch_for_toplevel_process(ctx, args, parser, subprocess_output, action)
+
+        # Act on results from subprocess execution
+
+        if is_completing():
+            return subprocess_output
+
+        if args.list:
+            print_actions(subprocess_output)
+            sys.exit(0)
+
+        truthy_actions = list(filter(None, actions))
+
+        if args.tree:
+            # TODO error out if there no actions could be printed
+            for k, v in subprocess_output.items():
+                if v.tree:
+                    print_tree(v.tree, truthy_actions)
+            sys.exit(0)
+
+        if not truthy_actions:
+            output_error("No actions specified and no default action is defined.\n")
+            print_actions(subprocess_output)
+            sys.exit(1)
+
+        sys.exit(0)
+
+    # We're in subprocess
+
+    # Always called with at most one action at a time; it is up to the caller to loop
+    # over the action list
+    assert len(args.actions) <= 1
+    subprocess_actions: list[str | None] = (
+        [args.actions[0]] if len(args.actions) > 0 else [None]
+    )
+    for action in subprocess_actions:
+        dispatch_for_subprocess(ctx, args, action)
+
+
+def dispatch_for_toplevel_process(
+    ctx: ByggContext,
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+    subprocess_output: dict[str, SubProcessIpcData],
+    action: str | None,
+):
+    """Dispatches an action in all environments."""
+    logger.info("Dispatch for toplevel process, action: {}", action)
+    for environment in ctx.configuration.environments:
+        assert environment
         # Check if we should restart with another Python interpreter (e.g. from a
         # virtualenv):
-        restart_with = apply_configuration(configuration, env, is_restarted_with_env)
+        restart_with = apply_configuration(ctx.configuration, environment, None)
+        assert restart_with is not None  # this should not happen
 
-        if restart_with is not None and not is_restarted_with_env:
-            exec_list = [restart_with, *partition.actions] + unparse_args(
-                parser, args, drop=["actions"]
+        # Create IPC file
+        fd, ipc_filename = tempfile.mkstemp()
+        os.close(fd)
+
+        exec_list = []
+        exec_list += [restart_with]
+        if action:
+            exec_list += [action]
+        exec_list += unparse_args(parser, args, drop=["actions"])
+        exec_list += ["--is_restarted_with_env", environment]
+        exec_list += ["--ipc_filename", ipc_filename]
+
+        logger.debug("Restarting with: {}", exec_list)
+        try:
+            process = subprocess.run(exec_list, encoding="utf-8")
+            if process.returncode == DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE:
+                continue
+            if process.returncode != 0:
+                sys.exit(process.returncode)
+        except FileNotFoundError:
+            output_error(f"Error: Could not restart with '{restart_with}'.")
+            output_warning(
+                "Please make sure that bygg is in your pip requirements list for this environment."
             )
-            if partition.environment_name:
-                exec_list += ["--is_restarted_with_env", partition.environment_name]
-
+            sys.exit(1)
+        finally:
             try:
-                process = subprocess.run(exec_list, encoding="utf-8")
-                if process.returncode != 0:
-                    sys.exit(process.returncode)
-            except FileNotFoundError:
-                output_error(f"Error: Could not restart with '{restart_with}'.")
-                output_warning(
-                    "Please make sure that bygg is in your pip requirements list for this environment."
-                )
-                sys.exit(1)
-        else:
-            status = do_dispatch(ctx, args, partition.actions)
-            if not status:
-                sys.exit(1)
+                with open(ipc_filename, "rb") as f:
+                    subprocess_output[environment] = msgspec.msgpack.decode(
+                        f.read(), type=SubProcessIpcData
+                    )
+            except (FileNotFoundError, msgspec.DecodeError) as e:
+                print(e)
+                pass
+            os.remove(ipc_filename)
 
 
-def do_dispatch(ctx: ByggContext, args: argparse.Namespace, actions: list[str]) -> bool:
+def dispatch_for_subprocess(
+    ctx: ByggContext, args: argparse.Namespace, action: str | None
+):
+    logger.info("Dispatch for subprocess")
+    logger.debug("Action: {}", action)
+    # We're in subprocess
+    ctx.ipc_data = SubProcessIpcData()
+    is_restarted_with_env = (
+        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
+    )
+    apply_configuration(ctx.configuration, is_restarted_with_env, is_restarted_with_env)
+
+    # Always fill the subprocess data
+    if ctx.ipc_data:
+        list_collect_subprocess(ctx, args)
+        entry_points = [
+            a.name for k, a in ctx.scheduler.build_actions.items() if a.is_entrypoint
+        ]
+        display_tree(ctx, entry_points)
+
+    ipc_filename = args.ipc_filename[0] if args.ipc_filename else None
+    if ipc_filename:
+        logger.debug("Writing IPC data to {}", args.ipc_filename)
+        with open(ipc_filename, "wb") as f:
+            f.write(msgspec.msgpack.encode(ctx.ipc_data))
+
+    if is_completing():
+        sys.exit(DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE)  # TODO change exit code
+
+    if action and action not in ctx.scheduler.build_actions:
+        sys.exit(DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE)
+
+    status = inner_dispatch(ctx, args)
+    if not status:
+        sys.exit(1)
+
+
+def inner_dispatch(ctx: ByggContext, args: argparse.Namespace) -> bool:
+    """
+    Executes the appropriate bygg commands on the supplied action list. Used both from
+    the toplevel in the case where there is no dedicated environment as well as when
+    each environment gets loaded in a subprocess.
+    """
+    logger.info("Doing dispatch")
     # Analysis implies building:
     always_make = args.always_make or args.check
+
+    if args.list:
+        list_actions(ctx, args)
+        return True
+
+    default_action = ctx.configuration.settings.default_action
+    actions = (
+        args.actions
+        if args.actions
+        else [default_action]
+        if default_action and default_action in ctx.scheduler.build_actions
+        else []
+    )
+
+    is_restarted_with_env = (
+        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
+    )
+    if is_restarted_with_env and not actions:
+        sys.exit(DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE)
+
+    if not actions:
+        output_error("No actions specified and no default action is defined.\n")
+        list_actions(ctx, args)
+        status = False
+
     if args.clean:
         status = clean(ctx, actions)
-    elif args.list:
-        list_actions(ctx)
-        status = True
-    elif not actions:
-        output_error("No actions specified and no default action is defined.\n")
-        list_actions(ctx)
-        status = False
     elif args.tree:
-        status = display_tree(ctx.scheduler, actions)
+        status = display_tree(ctx, actions)
     else:
         jobs = int(args.jobs) if args.jobs else None
         status = build(ctx, actions, jobs, always_make, args.check)
@@ -188,98 +313,38 @@ def do_dispatch(ctx: ByggContext, args: argparse.Namespace, actions: list[str]) 
     return status
 
 
-@dataclass
-class ActionPartition:
-    """
-    environment_name: The name of the environment that the actions should be run in.
-    None means the implicit default environment, i.e. typically the base process.
-
-    actions: The actions that should be run in the environment.
-    """
-
-    environment_name: str | None
-    actions: list[str]
-
-
-def partition_actions(
-    configuration: ByggFile,
-    actions: list[str] | None,
-) -> list[ActionPartition] | None:
-    """
-    Partition the actions into groups that should be run in the same environment. Only
-    partition the given actions that also exist in the configuration file. This is to
-    not have to load the Python build files for all the environments, since installing
-    their respective requirements can take a while.
-
-    Parameters
-    ----------
-    configuration : ByggFile
-        The configuration file.
-    actions : list[str] | None
-        The actions that should be run. If None, a partition will be created, resolved
-        to the default action.
-
-    Returns
-    -------
-    list[ActionPartition] | None
-        A list of ActionPartition objects, each representing a group of actions that
-        should be run in the same environment. Returns None if there are no actions in
-        the configuration.
-    """
-    if not configuration.actions:
-        return None
-
-    resolved_actions = actions if actions else []
-
-    if not resolved_actions and configuration.settings.default_action is not None:
-        # Resolve to default action:
-        resolved_actions += [configuration.settings.default_action]
-        return [ActionPartition("default", resolved_actions)]
-
-    # Put consecutive actions with the same environment in the same partition:
-    action_partitions = []
-    action_dict = {a.name: a for a in configuration.actions}
-    current_partition: ActionPartition | None = None
-    for action in [action_dict[a] for a in resolved_actions]:
-        if (
-            current_partition is None
-            or current_partition.environment_name != action.environment
-        ):
-            current_partition = ActionPartition(action.environment, [action.name])
-            action_partitions.append(current_partition)
-        else:
-            current_partition.actions.append(action.name)
-
-    return action_partitions
-
-
-def entrypoint_completions(prefix, parsed_args: argparse.Namespace, **kwargs):
+def entrypoint_completions(
+    prefix, parser: argparse.ArgumentParser, parsed_args: argparse.Namespace, **kwargs
+):
     import textwrap
 
-    # Handle -C/--directory:
-    new_dir = parsed_args.directory[0] if parsed_args.directory else None
+    subprocess_data = dispatcher(parser, parsed_args)
+    if not subprocess_data:
+        return {}
 
-    with change_dir(new_dir):
-        configuration = read_config_file()
-        ctx = init_bygg_context(configuration)
+    # There can technically only be one default_action, but easy way to consolidate:
+    default_actions = {
+        ipc_data.list.default_action
+        for env, ipc_data in subprocess_data.items()
+        if ipc_data.list is not None
+    }
 
-        if configuration.environments:
-            # We don't want to install environments while completing, so only load the
-            # actions from the static configuration file:
-            register_actions_from_configuration(ctx.configuration, None)
-        else:
-            apply_configuration(ctx.configuration, None, None)
+    env_actions = [
+        ipc_data.list.actions
+        for env, ipc_data in subprocess_data.items()
+        if ipc_data.list is not None
+    ]
 
-        entrypoints = get_entrypoints(ctx)
-        # Exlude already added entrypoints:
-        eligible_entrypoints = [
-            x for x in entrypoints if x.name not in parsed_args.actions
-        ]
-        # Fill the description really wide to get it combined to a single line with
-        # spaces dealt with correctly:
-        return {
-            x.name: textwrap.fill(x.description, 7000) for x in eligible_entrypoints
-        }
+    actions = {
+        name: textwrap.fill(
+            f"{'(default) ' if name in default_actions else ''}{description}", 7000
+        )
+        for action_set in env_actions
+        for name, description in action_set.items()
+        if name not in parsed_args.actions
+    }
+
+    return actions
 
 
 def create_argument_parser():
@@ -319,6 +384,14 @@ List available actions:
 
     parser.add_argument(
         "--is_restarted_with_env",
+        nargs=1,
+        type=str,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    # Used internally for communicating the IPC filename to the subprocess.
+    parser.add_argument(
+        "--ipc_filename",
         nargs=1,
         type=str,
         default=None,

--- a/src/bygg/cmd/list_actions.py
+++ b/src/bygg/cmd/list_actions.py
@@ -1,19 +1,63 @@
+import argparse
 import os
 import shutil
 import sys
 import textwrap
 
-from bygg.cmd.datastructures import ByggContext, get_entrypoints
+from bygg.cmd.datastructures import (
+    ByggContext,
+    EntryPoint,
+    SubProcessIpcData,
+    SubProcessIpcDataList,
+    get_entrypoints,
+)
 from bygg.output.output import (
     TerminalStyle as TS,
 )
 from bygg.output.output import output_error
+from loguru import logger
 
 list_actions_style = "B"
 
+HEADER = f"{TS.BOLD}Available actions:{TS.RESET}"
 
-def list_actions(ctx: ByggContext) -> bool:
-    entrypoints = get_entrypoints(ctx)
+
+def list_collect_subprocess(
+    ctx: ByggContext,
+    args: argparse.Namespace,
+) -> bool:
+    entrypoints = get_entrypoints(ctx, args)
+
+    is_restarted_with_env = (
+        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
+    )
+    if is_restarted_with_env and not entrypoints:
+        return False
+
+    sorted_actions = sorted(entrypoints, key=lambda x: x.name)
+    default_action_name = ctx.configuration.settings.default_action
+
+    if ctx.ipc_data:
+        logger.debug("Sorted actions: {}", sorted_actions)
+        ctx.ipc_data.list = SubProcessIpcDataList(
+            actions={x.name: x.description for x in sorted_actions},
+            default_action=default_action_name,
+        )
+        return True
+
+    return False
+
+
+def list_actions(ctx: ByggContext, args: argparse.Namespace) -> bool:
+    # TODO consider consolidating this function with print_actions
+
+    entrypoints = get_entrypoints(ctx, args)
+
+    is_restarted_with_env = (
+        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
+    )
+    if is_restarted_with_env and not entrypoints:
+        return False
 
     if not entrypoints:
         program_name = os.path.basename(sys.argv[0])
@@ -21,11 +65,18 @@ def list_actions(ctx: ByggContext) -> bool:
         output_error(f"Type `{program_name} --help` for help.")
         return False
 
-    terminal_cols, terminal_rows = shutil.get_terminal_size()
-    output = [f"{TS.BOLD}Available actions:{TS.RESET}"]
+    output = [HEADER]
 
     sorted_actions = sorted(entrypoints, key=lambda x: x.name)
     default_action_name = ctx.configuration.settings.default_action
+
+    if ctx.ipc_data:
+        logger.debug("Sorted actions: {}", sorted_actions)
+        ctx.ipc_data.list = SubProcessIpcDataList(
+            actions={x.name: x.description for x in sorted_actions},
+            default_action=default_action_name,
+        )
+        return True
 
     if default_action_name:
         default_action_list = [
@@ -39,40 +90,91 @@ def list_actions(ctx: ByggContext) -> bool:
             sorted_actions.insert(0, default_action)
 
     if list_actions_style == "A":
-        output.append("")
-        section_indent = 0
-        separator = " : "
-        max_name_width = max([len(x.name) for x in entrypoints])
-        width = min(terminal_cols, 80)
-        subsequent_indent = " " * (section_indent + max_name_width + len(separator))
-        for action in sorted_actions:
-            description = f"{TS.BOLD}{action.name: <{max_name_width}}{TS.RESET}{separator}{action.description}"
-            output.extend(
-                textwrap.wrap(
-                    description,
-                    width=width,
-                    initial_indent=" " * section_indent,
-                    subsequent_indent=subsequent_indent,
-                )
-            )
-            output.append("")
+        output += list_actions_A(sorted_actions)
 
     if list_actions_style == "B":
-        output.append("")
-        for action in sorted_actions:
-            default_action_suffix = (
-                " (default)" if action.name == default_action_name else ""
-            )
-            output.append(f"{TS.BOLD}{action.name}{default_action_suffix}{TS.RESET}")
-            output.append(
-                textwrap.fill(
-                    action.description,
-                    initial_indent="    ",
-                    subsequent_indent="    ",
-                )
-            )
-            output.append("")
+        output += list_actions_B(sorted_actions, default_action_name)
 
     print("\n".join(output))
 
     return True
+
+
+def list_actions_A(actions: list[EntryPoint]) -> list[str]:
+    terminal_cols, terminal_rows = shutil.get_terminal_size()
+
+    output: list[str] = []
+    output.append("")
+    section_indent = 0
+    separator = " : "
+    max_name_width = max([len(x.name) for x in actions])
+    width = min(terminal_cols, 80)
+    subsequent_indent = " " * (section_indent + max_name_width + len(separator))
+    for action in actions:
+        description = f"{TS.BOLD}{action.name: <{max_name_width}}{TS.RESET}{separator}{action.description}"
+        output.extend(
+            textwrap.wrap(
+                description,
+                width=width,
+                initial_indent=" " * section_indent,
+                subsequent_indent=subsequent_indent,
+            )
+        )
+        output.append("")
+    return output
+
+
+def list_actions_B(
+    actions: list[EntryPoint], default_action_name: str | None
+) -> list[str]:
+    output: list[str] = []
+    output.append("")
+    for action in actions:
+        default_action_suffix = (
+            " (default)" if action.name == default_action_name else ""
+        )
+        output.append(f"{TS.BOLD}{action.name}{default_action_suffix}{TS.RESET}")
+        output.append(
+            textwrap.fill(
+                action.description,
+                initial_indent="    ",
+                subsequent_indent="    ",
+            )
+        )
+        output.append("")
+    return output
+
+
+def print_actions(subprocess_output: dict[str, SubProcessIpcData]):
+    """Prints a list of actions from different environments."""
+    display_environment_names = (
+        len(
+            [
+                len(v.list.actions)
+                for k, v in subprocess_output.items()
+                if v.list and len(v.list.actions) > 0
+            ]
+        )
+        > 1
+    )
+
+    output = [HEADER]
+
+    if display_environment_names:
+        output.append("")
+
+    for env, data in sorted(
+        subprocess_output.items(),
+        key=lambda x: (0, x[0]) if x[0] == "default" else (1, x[0]),
+    ):
+        if not data.list:
+            continue
+
+        if display_environment_names:
+            output.append(f"~~ {env} ~~")
+
+        output += list_actions_B(
+            [EntryPoint(name, descr) for name, descr in data.list.actions.items()],
+            data.list.default_action,
+        )
+    print("\n".join(output))

--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -1,10 +1,14 @@
+"""
+A build tool written in Python, where all actions can be written in Python.
+"""
+
 # PYTHON_ARGCOMPLETE_OK
 
 import os
 
 from loguru import logger
 
-from bygg.cmd.dispatcher import dispatcher
+from bygg.cmd.dispatcher import bygg
 from bygg.output.output import output_warning
 
 
@@ -12,7 +16,7 @@ def main():
     setup_logging()
     logger.info("Starting")
     try:
-        return dispatcher()
+        return bygg()
     except KeyboardInterrupt:
         output_warning("Interrupted by user. Aborting.")
         return 1

--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -23,6 +23,7 @@
 # name: test_actions_completions[environments]
   list([
     'action1',
+    'action1_python_entrypoint_python',
     'action2',
     'clean_environments',
     'default_action',
@@ -31,6 +32,7 @@
 # name: test_actions_completions[environments].1
   list([
     'action1',
+    'action1_python_entrypoint_python',
     'action2',
     'clean_environments',
     'default_action',
@@ -39,6 +41,7 @@
 # name: test_actions_completions[environments].2
   list([
     'action1',
+    'action1_python_entrypoint_python',
     'action2',
     'clean_environments',
     'default_action',

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -237,19 +237,31 @@
 # ---
 # name: test_list[environments]
   '''
+  🛈 Setting up environment in .venv1
+  🛈 Setting up environment in .venv2
+  🛈 Setting up environment in .venv
   Available actions:
+  
+  ~~ default ~~
+  
+  clean_environments
+      Clean all environments
   
   default_action (default)
       The default action. Runs in the default environment.
   
+  ~~ env1 ~~
+  
   action1
       Action that runs in env1.
   
+  action1_python_entrypoint_python
+      An entrypoint action declared in Python.
+  
+  ~~ env2 ~~
+  
   action2
       Action that runs in env2.
-  
-  clean_environments
-      Clean all environments
   
   
   '''
@@ -346,19 +358,31 @@
 # name: test_list_directory[environments]
   '''
   🛈 Entering directory 'examples/environments'
+  🛈 Setting up environment in .venv1
+  🛈 Setting up environment in .venv2
+  🛈 Setting up environment in .venv
   Available actions:
+  
+  ~~ default ~~
+  
+  clean_environments
+      Clean all environments
   
   default_action (default)
       The default action. Runs in the default environment.
   
+  ~~ env1 ~~
+  
   action1
       Action that runs in env1.
   
+  action1_python_entrypoint_python
+      An entrypoint action declared in Python.
+  
+  ~~ env2 ~~
+  
   action2
       Action that runs in env2.
-  
-  clean_environments
-      Clean all environments
   
   
   '''
@@ -451,10 +475,12 @@
 # ---
 # name: test_tree[environments]
   '''
+  🛈 Setting up environment in .venv1
+  🛈 Setting up environment in .venv2
+  🛈 Setting up environment in .venv
   
   default_action
   └── default_action_python
-  🛈 Setting up environment in .venv
   
   '''
 # ---
@@ -828,11 +854,13 @@
 # ---
 # name: test_tree_directory[environments]
   '''
+  🛈 Entering directory 'examples/environments'
+  🛈 Setting up environment in .venv1
+  🛈 Setting up environment in .venv2
+  🛈 Setting up environment in .venv
   
   default_action
   └── default_action_python
-  🛈 Entering directory 'examples/environments'
-  🛈 Setting up environment in .venv
   
   '''
 # ---

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -85,16 +85,18 @@ actions_completions = [p for p in Path("examples").iterdir() if p.is_dir()]
 
 @pytest.mark.parametrize("arg", actions_completions, ids=lambda x: str(x.name))
 def test_actions_completions(completion_tester, arg, snapshot, clean_bygg_tree):
+    dir = str(arg)
     with change_dir(clean_bygg_tree):
-        dir = str(arg)
         testcase = f"-C {dir} "
         testresult = completion_tester(testcase)
         assert sorted(testresult.split("\x0b")) == snapshot
 
+    with change_dir(clean_bygg_tree):
         testcase = f"--directory {dir} "
         testresult = completion_tester(testcase)
         assert sorted(testresult.split("\x0b")) == snapshot
 
+    with change_dir(clean_bygg_tree):
         with change_dir(dir):
             testresult = completion_tester("")
             assert sorted(testresult.split("\x0b")) == snapshot

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,9 +1,13 @@
+from bygg.cmd.configuration import ByggFile
+from bygg.cmd.datastructures import ByggContext
 from bygg.cmd.tree import display_tree
+from bygg.core.runner import ProcessRunner
 
 
 def test_tree_single_action(scheduler_single_action, capsys, snapshot):
     scheduler, _ = scheduler_single_action
-    display_tree(scheduler, ["action1"])
+    ctx = ByggContext(ProcessRunner(scheduler), scheduler, ByggFile())
+    display_tree(ctx, ["action1"])
     stdout, _ = capsys.readouterr()
     assert stdout == snapshot
 
@@ -12,13 +16,15 @@ def test_tree_four_nonbranching_actions(
     scheduler_four_nonbranching_actions, capsys, snapshot
 ):
     scheduler, _ = scheduler_four_nonbranching_actions
-    display_tree(scheduler, ["action1"])
+    ctx = ByggContext(ProcessRunner(scheduler), scheduler, ByggFile())
+    display_tree(ctx, ["action1"])
     stdout, _ = capsys.readouterr()
     assert stdout == snapshot
 
 
 def test_tree_branching_actions(scheduler_branching_actions, capsys, snapshot):
     scheduler, _ = scheduler_branching_actions
-    display_tree(scheduler, ["action1"])
+    ctx = ByggContext(ProcessRunner(scheduler), scheduler, ByggFile())
+    display_tree(ctx, ["action1"])
     stdout, _ = capsys.readouterr()
     assert stdout == snapshot


### PR DESCRIPTION
Refactor the dispatcher mechanism to load each declared environment in its own subprocess and gather all entrypoints.

This implementation no longer groups consecutive actions by environment but executes each action one by one in its respective environment.

Adapt the completion mechanism to load the entrypoints via the dispatcher.

Closes #131.