### PR TITLE
Simplify is_restarted_with_env

### DIFF
--- a/src/bygg/cmd/datastructures.py
+++ b/src/bygg/cmd/datastructures.py
@@ -48,10 +48,6 @@ NO_DESCRIPTION = "No description"
 
 
 def get_entrypoints(ctx: ByggContext, args: argparse.Namespace) -> list[EntryPoint]:
-    is_restarted_with_env = (
-        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
-    )
-
     return [
         EntryPoint(x.name, x.description or NO_DESCRIPTION)
         for x in ctx.scheduler.build_actions.values()
@@ -59,5 +55,5 @@ def get_entrypoints(ctx: ByggContext, args: argparse.Namespace) -> list[EntryPoi
     ] or [
         EntryPoint(x.name, x.description or NO_DESCRIPTION)
         for x in ctx.configuration.actions
-        if x.is_entrypoint and x.environment == is_restarted_with_env
+        if x.is_entrypoint and x.environment == args.is_restarted_with_env
     ]

--- a/src/bygg/cmd/list_actions.py
+++ b/src/bygg/cmd/list_actions.py
@@ -29,10 +29,7 @@ def list_collect_subprocess(
 ) -> bool:
     entrypoints = get_entrypoints(ctx, args)
 
-    is_restarted_with_env = (
-        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
-    )
-    if is_restarted_with_env and not entrypoints:
+    if args.is_restarted_with_env and not entrypoints:
         return False
 
     sorted_actions = sorted(entrypoints, key=lambda x: x.name)
@@ -54,10 +51,7 @@ def list_actions(ctx: ByggContext, args: argparse.Namespace) -> bool:
 
     entrypoints = get_entrypoints(ctx, args)
 
-    is_restarted_with_env = (
-        args.is_restarted_with_env[0] if args.is_restarted_with_env else None
-    )
-    if is_restarted_with_env and not entrypoints:
+    if args.is_restarted_with_env and not entrypoints:
         return False
 
     if not entrypoints:


### PR DESCRIPTION
Make --is_restarted_with_env take nargs="?" instead of nargs=1, making the argparse namespace variable be a string instead of a list of strings. This allows for easier use of it throughout the code.

Closes #160.