### PR TITLE
Handle non-existing entrypoints in environments

### DIFF
--- a/src/bygg/cmd/datastructures.py
+++ b/src/bygg/cmd/datastructures.py
@@ -24,6 +24,8 @@ class SubProcessIpcDataTree(msgspec.Struct):
 class SubProcessIpcData(msgspec.Struct):
     """Holds the results for metadata from a subprocess."""
 
+    # Actions that were found
+    found_actions: set[str] = msgspec.field(default_factory=set)
     list: Optional[SubProcessIpcDataList] = None
     tree: Optional[SubProcessIpcDataTree] = None
 

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -139,36 +139,36 @@ def dispatcher(
         for action in actions:
             dispatch_for_toplevel_process(ctx, args, parser, subprocess_output, action)
 
-        # Act on results from subprocess execution
+            # Act on results from subprocess execution. Only actions that are to be
+            # built or cleaned need to continue the loop beyond the first pass.
 
-        if is_completing():
-            return subprocess_output
+            if is_completing():
+                return subprocess_output
 
-        if args.list:
-            print_actions(subprocess_output)
-            sys.exit(0)
+            if args.list:
+                print_actions(subprocess_output)
+                sys.exit(0)
 
-        truthy_actions = set(filter(None, actions))
-        found_actions: set[str] = set().union(
-            *(i.found_actions for i in subprocess_output.values())
-        )
-        missing_actions = truthy_actions - found_actions
+            truthy_actions = set(filter(None, actions))
+            found_actions: set[str] = set().union(
+                *(i.found_actions for i in subprocess_output.values())
+            )
 
-        for a in missing_actions:
-            output_error(f"Action '{a}' not found in any environment.")
-            sys.exit(1)
+            if action not in found_actions:
+                output_error(f"Action '{action}' not found in any environment.")
+                sys.exit(1)
 
-        if args.tree:
-            # TODO error out if there no actions could be printed
-            for k, v in subprocess_output.items():
-                if v.tree:
-                    print_tree(v.tree, list(truthy_actions))
-            sys.exit(0)
+            if args.tree:
+                # TODO error out if there no actions could be printed
+                for k, v in subprocess_output.items():
+                    if v.tree:
+                        print_tree(v.tree, list(truthy_actions))
+                sys.exit(0)
 
-        if not truthy_actions:
-            output_error("No actions specified and no default action is defined.\n")
-            print_actions(subprocess_output)
-            sys.exit(1)
+            if not truthy_actions:
+                output_error("No actions specified and no default action is defined.\n")
+                print_actions(subprocess_output)
+                sys.exit(1)
 
         sys.exit(0)
 

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -460,6 +460,64 @@
   
   '''
 # ---
+# name: test_non_existing_action[checks]
+  '''
+  🛈 Entering directory 'examples/checks'
+  🛈 Building action 'no_such_action':
+  Error: Action ''no_such_action'' not found.
+  
+  '''
+# ---
+# name: test_non_existing_action[environments]
+  '''
+  🛈 Entering directory 'examples/environments'
+  🛈 Setting up environment in .venv1
+  🛈 Setting up environment in .venv2
+  🛈 Setting up environment in .venv
+  Action 'no_such_action' not found in any environment.
+  
+  '''
+# ---
+# name: test_non_existing_action[failing_jobs]
+  '''
+  🛈 Entering directory 'examples/failing_jobs'
+  🛈 Building action 'no_such_action':
+  Error: Action ''no_such_action'' not found.
+  
+  '''
+# ---
+# name: test_non_existing_action[only_python]
+  '''
+  🛈 Entering directory 'examples/only_python'
+  🛈 Building action 'no_such_action':
+  Error: Action ''no_such_action'' not found.
+  
+  '''
+# ---
+# name: test_non_existing_action[parametric]
+  '''
+  🛈 Entering directory 'examples/parametric'
+  🛈 Building action 'no_such_action':
+  Error: Action ''no_such_action'' not found.
+  
+  '''
+# ---
+# name: test_non_existing_action[taskrunner]
+  '''
+  🛈 Entering directory 'examples/taskrunner'
+  🛈 Building action 'no_such_action':
+  Error: Action ''no_such_action'' not found.
+  
+  '''
+# ---
+# name: test_non_existing_action[trivial]
+  '''
+  🛈 Entering directory 'examples/trivial'
+  🛈 Building action 'no_such_action':
+  Error: Action ''no_such_action'' not found.
+  
+  '''
+# ---
 # name: test_tree[checks]
   '''
   

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,3 +98,15 @@ def test_version():
     # are set etc, so only do a rudimentary check for numbers in a major-minor pattern.
     cleaned_version = process.stdout[7:].strip()
     assert re.match(r"\d+\.\d+", cleaned_version)
+
+
+@pytest.mark.parametrize("example", examples, ids=lambda x: x.name)
+def test_non_existing_action(snapshot, clean_bygg_tree, example):
+    process = subprocess.run(
+        ["bygg", "no_such_action", "-C", examples_dir / example.name],
+        cwd=clean_bygg_tree,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert process.returncode == 1
+    assert process.stdout == snapshot


### PR DESCRIPTION
Have the dispatcher keep track of if the entrypoints were actually processed when called for different environments and exit with the appropriate error code.

Add tests.