### PR TITLE
Set fail-fast to false in Code quality workflow

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -14,6 +14,7 @@ jobs:
         nox_session: [tests, basics, examples]
         os: [ubuntu-latest, macos-latest, macos-14]
         install_uv: [0, 1]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -37,6 +38,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.11.9", "3.12.3"]
+      fail-fast: false
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Let the matrix jobs finish even if one or several fail. This makes it easier to get an overview of any breakage.