### PR TITLE
Return correct exit code when no action is given

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,8 @@ def examples(session):
         session.run("bygg", success_codes=[1])
         session.run("bygg", "hello")
         session.run("bygg", "hello", "--tree")
-        session.run("bygg", "--clean")
+        session.run("bygg", "--clean", success_codes=[1])
+        session.run("bygg", "hello", "--clean")
 
     with session.chdir("examples/parametric"):
         session.run("bygg")

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -292,8 +292,7 @@ def inner_dispatch(ctx: ByggContext, args: argparse.Namespace) -> bool:
         output_error("No actions specified and no default action is defined.\n")
         list_actions(ctx, args)
         status = False
-
-    if args.clean:
+    elif args.clean:
         status = clean(ctx, actions)
     elif args.tree:
         status = display_tree(ctx, actions)


### PR DESCRIPTION
Return the correct exit code when no action is given and no default action exists in a Python-only project.

Adjust test to expect the correct exit code, and add test that should work.