### PR TITLE
Create status directory before writing cache file

### DIFF
--- a/src/bygg/core/cache.py
+++ b/src/bygg/core/cache.py
@@ -38,6 +38,7 @@ class Cache:
     def save(self):
         if not self.data:
             return
+        make_sure_status_dir_exists()
         with open(self.db_file, "wb") as f:
             pickle.dump(self.data, f)
         # print(f"Cache: {self.data.digests}")


### PR DESCRIPTION
The cache directory would not have been created before saving the cache if not building any actions in a project, causing a crash.

Discovered in the nox logs for examples/only_python/. The crash would not cause the nox job to fail because the case where it happened actually should exit with the return code 1.

Add a call to make_sure_status_dir_exists.

Regression introduced in 4403ed67e267067c996004448d1f1ca6fed155ff.