### PR TITLE
Have --tree deal with non-existing entrypoints

### DIFF
--- a/src/bygg/cmd/tree.py
+++ b/src/bygg/cmd/tree.py
@@ -2,6 +2,7 @@ from itertools import chain
 
 from bygg.cmd.datastructures import ByggContext, SubProcessIpcDataTree
 from bygg.output.output import TerminalStyle as TS
+from bygg.output.output import output_error
 
 
 class TreeStyle:
@@ -62,6 +63,9 @@ def display_tree(ctx: ByggContext, entry_points: list[str]):
 
     for entry_point in entry_points:
         build_actions = ctx.scheduler.build_actions
+        if not ctx.ipc_data and entry_point not in build_actions:
+            output_error(f"Error: Action '{entry_point}' not found.")
+            return False
 
         def format_children(name: str, last_sibling: bool, depth: int) -> list[str]:
             action = build_actions[name]

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -1281,3 +1281,48 @@
   
   '''
 # ---
+# name: test_tree_non_existing_action[checks]
+  '''
+  Error: Action 'no_such_action' not found.
+  
+  '''
+# ---
+# name: test_tree_non_existing_action[environments]
+  '''
+  🛈 Setting up environment in .venv1
+  🛈 Setting up environment in .venv2
+  🛈 Setting up environment in .venv
+  Action 'no_such_action' not found in any environment.
+  
+  '''
+# ---
+# name: test_tree_non_existing_action[failing_jobs]
+  '''
+  Error: Action 'no_such_action' not found.
+  
+  '''
+# ---
+# name: test_tree_non_existing_action[only_python]
+  '''
+  Error: Action 'no_such_action' not found.
+  
+  '''
+# ---
+# name: test_tree_non_existing_action[parametric]
+  '''
+  Error: Action 'no_such_action' not found.
+  
+  '''
+# ---
+# name: test_tree_non_existing_action[taskrunner]
+  '''
+  Error: Action 'no_such_action' not found.
+  
+  '''
+# ---
+# name: test_tree_non_existing_action[trivial]
+  '''
+  Error: Action 'no_such_action' not found.
+  
+  '''
+# ---

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,6 +74,22 @@ def test_tree_directory(snapshot, clean_bygg_tree, example):
     assert process.stdout == snapshot
 
 
+@pytest.mark.parametrize("example", examples, ids=lambda x: x.name)
+def test_tree_non_existing_action(snapshot, clean_bygg_tree, example):
+    process = subprocess.run(
+        ["bygg", "--tree", "no_such_action"],
+        cwd=clean_bygg_tree / examples_dir / example.name,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert process.returncode == 1
+    assert process.stdout == snapshot
+
+
+# TODO more tests:
+# --tree ACTION (one and several existing )
+
+
 def test_dump_schema(snapshot):
     process = subprocess.run(
         ["bygg", "--dump-schema"],


### PR DESCRIPTION
Return False when encountering a non-existing entrypoint and not running in a subprocess.

Add tests.