### PR TITLE
Break out argparser setup into its own file

### DIFF
--- a/src/bygg/cmd/argument_parsing.py
+++ b/src/bygg/cmd/argument_parsing.py
@@ -1,0 +1,130 @@
+import argparse
+from typing import Any
+
+from argcomplete.completers import BaseCompleter
+from bygg.cmd.completions import ByggfileDirectoriesCompleter
+from loguru import logger
+
+
+def create_argument_parser(entrypoint_completions: BaseCompleter):
+    logger.info("Creating argument parser")
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+A build tool written in Python, where all actions can be written in Python.
+
+Build the default action:
+ %(prog)s
+
+Build ACTION:
+ %(prog)s ACTION
+
+Clean ACTION:
+ %(prog)s ACTION --clean
+
+List available actions:
+ %(prog)s --list
+""",
+    )
+
+    # Use Any to get around type checking for argcomplete:
+    arg: Any = parser.add_argument(
+        "actions",
+        nargs="*",
+        default=None,
+        help="Entrypoint actions to operate on.",
+    )
+    arg.completer = entrypoint_completions
+
+    parser.add_argument(
+        "-v", "--version", action="store_true", help="Show version string and exit."
+    )
+
+    parser.add_argument(
+        "--is_restarted_with_env",
+        nargs="?",
+        type=str,
+        help=argparse.SUPPRESS,
+    )
+    # Used internally for communicating the IPC filename to the subprocess.
+    parser.add_argument(
+        "--ipc_filename",
+        nargs=1,
+        type=str,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    # Commands that operate on the build setup:
+    build_setup_wrapper_group = parser.add_argument_group(
+        "Commands that operate on the build setup"
+    )  # add_mutually_exclusive_group doesn't accept a title, so wrap it in a regular group.
+    build_setup_group = build_setup_wrapper_group.add_mutually_exclusive_group()
+    build_setup_group.add_argument(
+        "--clean",
+        action="store_true",
+        help="Clean the outputs of the specified actions.",
+    )
+    build_setup_group.add_argument(
+        "-l",
+        "--list",
+        action="store_true",
+        help="List available actions.",
+    )
+    build_setup_group.add_argument(
+        "--tree",
+        action="store_true",
+        help="Display the dependency tree starting from the specified action(s).",
+    )
+    # Some arguments inspired by Make:
+    make_group = parser.add_argument_group("Make-like arguments")
+    arg = make_group.add_argument(
+        "-C",
+        "--directory",
+        nargs=1,
+        type=str,
+        default=None,
+        help="Change to the specified directory.",
+    )
+    arg.completer = ByggfileDirectoriesCompleter()
+
+    make_group.add_argument(
+        "-j",
+        "--jobs",
+        nargs="?",
+        type=int,
+        default=None,
+        help="Specify the number of jobs to run simultaneously. None means to use the number of available cores.",
+    )
+    make_group.add_argument(
+        "-B",
+        "--always-make",
+        action="store_true",
+        help="Always build all actions.",
+    )
+
+    # Analyse and verify:
+    analyse_group = parser.add_argument_group(
+        "Analyse and verify",
+        "Arguments in this group will add more analysis to the build process. Actions will be built and the analysis result will be reported.",
+    )
+    analyse_group.add_argument(
+        "--check",
+        action="store_true",
+        help="Perform various checks on the action tree. Implies -B",
+    )
+
+    # Meta arguments:
+    meta_group = parser.add_argument_group("Meta arguments")
+    meta_group.add_argument(
+        "--dump-schema",
+        action="store_true",
+        help="Generate a JSON Schema for the Byggfile.yml files. The schema will be printed to stdout.",
+    )
+    meta_group.add_argument(
+        "--completions",
+        action="store_true",
+        help="Output instructions for how to set up shell completions via the shell's startup script.",
+    )
+
+    return parser

--- a/tests/test_argument_unparsing.py
+++ b/tests/test_argument_unparsing.py
@@ -1,5 +1,5 @@
 from bygg.cmd.argument_unparsing import unparse_args
-from bygg.cmd.dispatcher import create_argument_parser
+from bygg.cmd.dispatcher import EntrypointCompleter, create_argument_parser
 import pytest
 
 args = [
@@ -24,13 +24,13 @@ args = [
 @pytest.mark.parametrize("arg", args, ids=lambda x: " ".join(x[0]))
 def test_unparse_args(arg):
     in_arg, out_arg = arg
-    parser = create_argument_parser()
+    parser = create_argument_parser(EntrypointCompleter())
     parsed_args = parser.parse_args(in_arg)
     assert sorted(unparse_args(parser, parsed_args)) == sorted(out_arg)
 
 
 def test_unparse_args_drop():
-    parser = create_argument_parser()
+    parser = create_argument_parser(EntrypointCompleter())
     parsed_args = parser.parse_args(["-C", "foo/bar", "action1", "-B"])
     assert sorted(unparse_args(parser, parsed_args, drop=["directory"])) == sorted(
         ["action1", "--always-make"]

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from bygg.cmd.completions import ByggCompletionFinder
-from bygg.cmd.dispatcher import create_argument_parser
+from bygg.cmd.dispatcher import EntrypointCompleter, create_argument_parser
 from bygg.system_helpers import change_dir
 import pytest
 
@@ -31,7 +31,7 @@ def completion_tester(monkeypatch, tmp_path):
         # to get its knickers in a twist.
         monkeypatch.setattr("os.fdopen", open_raise)
 
-        parser = create_argument_parser()
+        parser = create_argument_parser(EntrypointCompleter())
         completer = ByggCompletionFinder()
 
         with open(outfile, "w", encoding="utf-8"):


### PR DESCRIPTION
Also change the entrypoint completer to be a class instead of a function. This makes it easier to type correctly.