### PR TITLE
Add name attribute to the environment schema

### DIFF
--- a/examples/environments/Byggfile.yml
+++ b/examples/environments/Byggfile.yml
@@ -27,6 +27,7 @@ actions:
 
 environments:
   env1:
+    name: "Environment 1"
     byggfile: "Byggfile1.py"
     inputs:
       - "requirements1.txt"
@@ -43,6 +44,7 @@ environments:
       fi
 
   env2:
+    # Leaving this environment without a human-friendly name for testing purposes
     byggfile: "Byggfile2.py"
     inputs:
       - "requirements2.txt"
@@ -59,6 +61,7 @@ environments:
       fi
 
   default:
+    name: "Default environment"
     byggfile: "Byggfile.py"
     inputs:
       - requirements.txt

--- a/schemas/Byggfile_yml_schema.json
+++ b/schemas/Byggfile_yml_schema.json
@@ -158,7 +158,7 @@
     },
     "Environment": {
       "title": "Environment",
-      "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\nbyggfile : str\n    The Python Byggfile that uses this environment.\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\ndescription : str, optional\n    A description of the environment. Used in e.g. help messages, by default None\nmessage : str, optional\n    A message related to the environment, by default None",
+      "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\nbyggfile : str\n    The Python Byggfile that uses this environment.\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by default None",
       "type": "object",
       "properties": {
         "byggfile": {
@@ -176,18 +176,7 @@
         "shell": {
           "type": "string"
         },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "message": {
+        "name": {
           "anyOf": [
             {
               "type": "string"

--- a/src/bygg/cmd/apply_configuration.py
+++ b/src/bygg/cmd/apply_configuration.py
@@ -39,11 +39,13 @@ def setup_environment(environment: Environment):
     # TODO should we remove the whole venv or just trust pip to do the right thing? For
     # now, remove the venv.
 
+    environment_name = f' "{environment.name}" ' if environment.name else " "
+
     if venv_path.exists():
-        output_info(f"Replacing venv at {venv_path}")
+        output_info(f"Replacing venv{environment_name}at {venv_path}")
         shutil.rmtree(venv_path)
 
-    output_info(f"Setting up environment in {venv_path}")
+    output_info(f"Setting up environment{environment_name}in {venv_path}")
     process = subprocess.run(
         environment.shell,
         shell=True,

--- a/src/bygg/cmd/configuration.py
+++ b/src/bygg/cmd/configuration.py
@@ -71,18 +71,15 @@ class Environment(msgspec.Struct, forbid_unknown_fields=True):
         Bygg if any of the inputs are modified.
     shell : str
         The shell command for creating the environment.
-    description : str, optional
-        A description of the environment. Used in e.g. help messages, by default None
-    message : str, optional
-        A message related to the environment, by default None
+    name : str, optional
+        A human-friendly name for the environment. Used in e.g. help messages, by default None
     """
 
     byggfile: str
     inputs: list[str]
     venv_directory: str
     shell: str
-    description: Optional[str] = None
-    message: Optional[str] = None
+    name: Optional[str] = None
 
 
 class ByggFile(msgspec.Struct, forbid_unknown_fields=True):

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -146,7 +146,7 @@ def dispatcher(
                 return subprocess_output
 
             if args.list:
-                print_actions(subprocess_output)
+                print_actions(ctx, subprocess_output)
                 sys.exit(0)
 
             truthy_actions = set(filter(None, actions))
@@ -167,7 +167,7 @@ def dispatcher(
 
             if not truthy_actions:
                 output_error("No actions specified and no default action is defined.\n")
-                print_actions(subprocess_output)
+                print_actions(ctx, subprocess_output)
                 sys.exit(1)
 
         sys.exit(0)

--- a/src/bygg/cmd/list_actions.py
+++ b/src/bygg/cmd/list_actions.py
@@ -140,7 +140,7 @@ def list_actions_B(
     return output
 
 
-def print_actions(subprocess_output: dict[str, SubProcessIpcData]):
+def print_actions(ctx: ByggContext, subprocess_output: dict[str, SubProcessIpcData]):
     """Prints a list of actions from different environments."""
     display_environment_names = (
         len(
@@ -166,7 +166,12 @@ def print_actions(subprocess_output: dict[str, SubProcessIpcData]):
             continue
 
         if display_environment_names:
-            output.append(f"~~ {env} ~~")
+            # Get the human-friendly name or fall back to the environment key:
+            environment = ctx.configuration.environments.get(env)
+            environment_name = (
+                environment.name if environment and environment.name else env
+            )
+            output.append(f"~~ {environment_name} ~~")
 
         output += list_actions_B(
             [EntryPoint(name, descr) for name, descr in data.list.actions.items()],

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -161,7 +161,7 @@
       },
       "Environment": {
         "title": "Environment",
-        "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\nbyggfile : str\n    The Python Byggfile that uses this environment.\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\ndescription : str, optional\n    A description of the environment. Used in e.g. help messages, by default None\nmessage : str, optional\n    A message related to the environment, by default None",
+        "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\nbyggfile : str\n    The Python Byggfile that uses this environment.\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by default None",
         "type": "object",
         "properties": {
           "byggfile": {
@@ -179,18 +179,7 @@
           "shell": {
             "type": "string"
           },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null
-          },
-          "message": {
+          "name": {
             "anyOf": [
               {
                 "type": "string"
@@ -237,12 +226,12 @@
 # ---
 # name: test_list[environments]
   '''
-  🛈 Setting up environment in .venv1
+  🛈 Setting up environment "Environment 1" in .venv1
   🛈 Setting up environment in .venv2
-  🛈 Setting up environment in .venv
+  🛈 Setting up environment "Default environment" in .venv
   Available actions:
   
-  ~~ default ~~
+  ~~ Default environment ~~
   
   clean_environments
       Clean all environments
@@ -250,7 +239,7 @@
   default_action (default)
       The default action. Runs in the default environment.
   
-  ~~ env1 ~~
+  ~~ Environment 1 ~~
   
   action1
       Action that runs in env1.
@@ -358,12 +347,12 @@
 # name: test_list_directory[environments]
   '''
   🛈 Entering directory 'examples/environments'
-  🛈 Setting up environment in .venv1
+  🛈 Setting up environment "Environment 1" in .venv1
   🛈 Setting up environment in .venv2
-  🛈 Setting up environment in .venv
+  🛈 Setting up environment "Default environment" in .venv
   Available actions:
   
-  ~~ default ~~
+  ~~ Default environment ~~
   
   clean_environments
       Clean all environments
@@ -371,7 +360,7 @@
   default_action (default)
       The default action. Runs in the default environment.
   
-  ~~ env1 ~~
+  ~~ Environment 1 ~~
   
   action1
       Action that runs in env1.
@@ -471,9 +460,9 @@
 # name: test_non_existing_action[environments]
   '''
   🛈 Entering directory 'examples/environments'
-  🛈 Setting up environment in .venv1
+  🛈 Setting up environment "Environment 1" in .venv1
   🛈 Setting up environment in .venv2
-  🛈 Setting up environment in .venv
+  🛈 Setting up environment "Default environment" in .venv
   Action 'no_such_action' not found in any environment.
   
   '''
@@ -533,9 +522,9 @@
 # ---
 # name: test_tree[environments]
   '''
-  🛈 Setting up environment in .venv1
+  🛈 Setting up environment "Environment 1" in .venv1
   🛈 Setting up environment in .venv2
-  🛈 Setting up environment in .venv
+  🛈 Setting up environment "Default environment" in .venv
   
   default_action
   └── default_action_python
@@ -913,9 +902,9 @@
 # name: test_tree_directory[environments]
   '''
   🛈 Entering directory 'examples/environments'
-  🛈 Setting up environment in .venv1
+  🛈 Setting up environment "Environment 1" in .venv1
   🛈 Setting up environment in .venv2
-  🛈 Setting up environment in .venv
+  🛈 Setting up environment "Default environment" in .venv
   
   default_action
   └── default_action_python
@@ -1289,9 +1278,9 @@
 # ---
 # name: test_tree_non_existing_action[environments]
   '''
-  🛈 Setting up environment in .venv1
+  🛈 Setting up environment "Environment 1" in .venv1
   🛈 Setting up environment in .venv2
-  🛈 Setting up environment in .venv
+  🛈 Setting up environment "Default environment" in .venv
   Action 'no_such_action' not found in any environment.
   
   '''


### PR DESCRIPTION
The name attribute can be used as a human-friendly name for the environment. Currently displayed during environment (re)install and in the action listing.

Remove the unused attributes "description" and "message".

Closes #154.