### PR TITLE
Fix input list bug in action_set

### DIFF
--- a/src/bygg/core/action.py
+++ b/src/bygg/core/action.py
@@ -203,7 +203,7 @@ def action_set(
             Action(
                 action_name,
                 message,
-                inputs=[input_file] + list(extra_inputs) if extra_inputs else None,
+                inputs=[input_file] + (list(extra_inputs) if extra_inputs else []),
                 outputs=[output_file],
                 dependencies=dependencies,
                 command=func,

--- a/testcases/action_set/Byggfile.py
+++ b/testcases/action_set/Byggfile.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+
+from bygg.core.action import ActionContext, action_set
+from bygg.core.common_types import CommandStatus
+
+static_file_pairs = [
+    ("files/a.txt", "files/out/a.txt"),
+    ("files/b.txt", "files/out/b.txt"),
+    ("files/c.txt", "files/out/c.txt"),
+]
+
+
+@action_set(
+    "testfiles_static",
+    message="Transforming file",
+    file_pairs=static_file_pairs,
+    is_entrypoint=True,
+)
+def transform_testfile(ctx: ActionContext):
+    if not ctx.inputs or not ctx.outputs:
+        return CommandStatus(1, "No inputs or outputs.", None)
+    for input_file, output_file in zip(ctx.inputs, ctx.outputs):
+        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+        shutil.copy(input_file, output_file)
+    return CommandStatus(0, f"{ctx.inputs} -> {ctx.outputs}", None)

--- a/testcases/action_set/files/a.txt
+++ b/testcases/action_set/files/a.txt
@@ -1,0 +1,1 @@
+This is a dummy test file a.txt.

--- a/testcases/action_set/files/b.txt
+++ b/testcases/action_set/files/b.txt
@@ -1,0 +1,1 @@
+This is a dummy test file b.txt.

--- a/testcases/action_set/files/c.txt
+++ b/testcases/action_set/files/c.txt
@@ -1,0 +1,1 @@
+This is a dummy test file c.txt.

--- a/tests/__snapshots__/test_testcases.ambr
+++ b/tests/__snapshots__/test_testcases.ambr
@@ -1,0 +1,33 @@
+# serializer version: 1
+# name: test_list[action_set]
+  list([
+    'Byggfile.py',
+    'files',
+    'files/a.txt',
+    'files/b.txt',
+    'files/c.txt',
+  ])
+# ---
+# name: test_list[action_set].1
+  list([
+    'Byggfile.py',
+    'files',
+    'files/a.txt',
+    'files/b.txt',
+    'files/c.txt',
+    'files/out',
+    'files/out/a.txt',
+    'files/out/b.txt',
+    'files/out/c.txt',
+  ])
+# ---
+# name: test_list[action_set].2
+  list([
+    'Byggfile.py',
+    'files',
+    'files/a.txt',
+    'files/b.txt',
+    'files/c.txt',
+    'files/out',
+  ])
+# ---

--- a/tests/test_testcases.py
+++ b/tests/test_testcases.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+@dataclass
+class TestcaseParameters:
+    __test__ = False
+    name: str
+    actions: list[str]
+
+
+testcases_dir = Path("testcases")
+
+testcases: list[TestcaseParameters] = [
+    TestcaseParameters("action_set", ["testfiles_static"]),
+]
+
+
+filetree_ignore = (
+    "__pycache__",
+    ".bygg",
+)
+
+
+def filetree(path: str):
+    return sorted(
+        [
+            str(p.relative_to(path))
+            for p in Path(path).rglob("**/*")
+            if not any(sub in str(p) for sub in filetree_ignore)
+        ]
+    )
+
+
+@pytest.mark.parametrize("testcase", testcases, ids=lambda x: x.name)
+def test_list(snapshot, clean_bygg_tree, testcase):
+    example_path = clean_bygg_tree / testcases_dir / testcase.name
+
+    # assert filetree_before == snapshot
+
+    process = subprocess.run(
+        ["bygg", "--list"],
+        cwd=clean_bygg_tree / testcases_dir / testcase.name,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert process.returncode == 0
+    assert filetree(example_path) == snapshot
+
+    for action in testcase.actions:
+        process = subprocess.run(
+            ["bygg", action],
+            cwd=clean_bygg_tree / testcases_dir / testcase.name,
+            capture_output=True,
+            encoding="utf-8",
+        )
+        assert process.returncode == 0
+        assert filetree(example_path) == snapshot
+
+        process = subprocess.run(
+            ["bygg", action, "--clean"],
+            cwd=clean_bygg_tree / testcases_dir / testcase.name,
+            capture_output=True,
+            encoding="utf-8",
+        )
+        assert process.returncode == 0
+        assert filetree(example_path) == snapshot


### PR DESCRIPTION
The input list of the Actions created by the action_set decorator would be empty unless extra_inputs was also passed in.

Add a test for this.

Add a testcases directory intended to hold tests for small end-to-end testcases like this, run with pytest.