### PR TITLE
Implement check for same output files

### DIFF
--- a/examples/checks/Byggfile.yml
+++ b/examples/checks/Byggfile.yml
@@ -9,6 +9,7 @@ actions:
     dependencies:
       - check_inputs_outputs
       - output_file_missing
+      - same_output_files
 
   # Circular dependencies
   - name: "circular_A"
@@ -50,4 +51,21 @@ actions:
   - name: "no_outputs_A"
     is_entrypoint: false
     outputs: ["no_outputs_A"]
+    shell: "true"
+
+  # Actions that create the same outputs
+  - name: "same_output_files"
+    description: |
+      Example where several actions create the same outputs. This should trigger same_output_files
+      when run with --check.
+    dependencies: ["same_output_file_A", "same_output_file_B"]
+
+  - name: "same_output_file_A"
+    is_entrypoint: false
+    outputs: ["same_output_file_A.txt", "common_output_file.txt"]
+    shell: "true"
+
+  - name: "same_output_file_B"
+    is_entrypoint: false
+    outputs: ["same_output_file_B.txt", "common_output_file.txt"]
     shell: "true"

--- a/src/bygg/output/status_display.py
+++ b/src/bygg/output/status_display.py
@@ -61,7 +61,7 @@ def on_job_status(
             raise ValueError(f"Unhandled job status {job_status}")
 
 
-CheckRule = Literal["check_inputs_outputs", "output_file_missing"]
+CheckRule = Literal["check_inputs_outputs", "output_file_missing", "same_output_files"]
 """
 The different rules that can be checked.
 
@@ -70,6 +70,8 @@ The different rules that can be checked.
 
     output_file_missing: Check that actions create the files that they declare as
     outputs.
+
+    same_output_files: Check that different actions don't produce the same output files.
 """
 
 

--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -4,6 +4,7 @@
     'all_checks',
     'check_inputs_outputs',
     'output_file_missing',
+    'same_output_files',
   ])
 # ---
 # name: test_actions_completions[checks].1
@@ -11,6 +12,7 @@
     'all_checks',
     'check_inputs_outputs',
     'output_file_missing',
+    'same_output_files',
   ])
 # ---
 # name: test_actions_completions[checks].2
@@ -18,6 +20,7 @@
     'all_checks',
     'check_inputs_outputs',
     'output_file_missing',
+    'same_output_files',
   ])
 # ---
 # name: test_actions_completions[environments]

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -221,6 +221,10 @@
       Example that doesn't create the outputs that it declares. This
       should trigger output_file_missing when run with --check.
   
+  same_output_files
+      Example where several actions create the same outputs. This should
+      trigger same_output_files when run with --check.
+  
   
   '''
 # ---
@@ -340,6 +344,10 @@
   output_file_missing
       Example that doesn't create the outputs that it declares. This
       should trigger output_file_missing when run with --check.
+  
+  same_output_files
+      Example where several actions create the same outputs. This should
+      trigger same_output_files when run with --check.
   
   
   '''
@@ -515,8 +523,11 @@
   │   └── circular_C
   │       └── circular_B
   │           └── circular_A
-  └── output_file_missing
-      └── no_outputs_A
+  ├── output_file_missing
+  │   └── no_outputs_A
+  └── same_output_files
+      ├── same_output_file_A
+      └── same_output_file_B
   
   '''
 # ---
@@ -894,8 +905,11 @@
   │   └── circular_C
   │       └── circular_B
   │           └── circular_A
-  └── output_file_missing
-      └── no_outputs_A
+  ├── output_file_missing
+  │   └── no_outputs_A
+  └── same_output_files
+      ├── same_output_file_A
+      └── same_output_file_B
   
   '''
 # ---


### PR DESCRIPTION
Check if several actions declare the same output files. Enabled by passing the --check flag.