### PR TITLE
Install prebuilt Python via mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,2 @@
-[settings]
-python_compile = true
-
 [tools]
 python = ["3.12.3", "3.11.9"]


### PR DESCRIPTION
Install prebuilt Python via mise instead of building from source.