### PR TITLE
Run Code quality workflow on specific OS versions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python_version: ["3.11.9", "3.12.8"]
         nox_session: [tests, basics, examples]
-        os: [ubuntu-latest, macos-latest, macos-14]
+        os: [ubuntu-24.04, macos-14]
         install_uv: [0, 1]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Change to running the Code quality workflow on specific OS versions: ubuntu-24.04 and macos-14 instead of *-latest.

Also, macOS-latest and macos-14 (that were previously both included) now point to the same runners, so fewer jobs will have to run now.

Pinning the versions means that the results will be more predictable.