### PR TITLE
Add --reinstall to uv in bootstrap.py

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -10,7 +10,7 @@ venv = Path(".venv")
 
 uv_bin = shutil.which("uv")
 venv_command = "python3 -m venv" if not uv_bin else f"{uv_bin} venv"
-pip_install_command = ".venv/bin/pip install" if not uv_bin else f"{uv_bin} pip install"
+pip_install_command = ".venv/bin/pip install" if not uv_bin else f"{uv_bin} pip install --reinstall"
 
 # Always remove existing venv, to make sure requirements are correctly installed.
 if venv.exists():


### PR DESCRIPTION
uv can sometimes be a bit zealous about caching packages, so that the latest versions from the requirements files would be replaced by the previous ones when installing bygg from the current directory.

Add --reinstall to force it to keep the latest versions; the install is still very fast.