### PR TITLE
Have uv always reinstall bygg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ ignore = ["E501"]
 [tool.ruff.lint.isort]
 order-by-type = true
 force-sort-within-sections = true
+
+[tool.uv]
+reinstall-package = ["bygg"]


### PR DESCRIPTION
uv would cache the local directory install of the package too aggressively, which was problematic e.g. when running nox and iterating over problems.