### PR TITLE
Use standard library logging instead of loguru

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,5 @@ argcomplete==3.5.2
 cattrs==24.1.2
 dc-schema==0.0.8
 dill==0.3.9
-loguru==0.7.2
 multiprocess==0.70.17
 PyYAML==6.0.2 # cattrs requires this as an ambient

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,6 @@ dill==0.3.9 \
     # via
     #   -r requirements.in
     #   multiprocess
-loguru==0.7.2 \
-    --hash=sha256:003d71e3d3ed35f0f8984898359d65b79e5b21943f78af86aa5491210429b8eb \
-    --hash=sha256:e671a53522515f34fd406340ee968cb9ecafbc4b36c679da03c18fd8d0bd51ac
-    # via -r requirements.in
 multiprocess==0.70.17 \
     --hash=sha256:1d52f068357acd1e5bbc670b273ef8f81d57863235d9fbf9314751886e141968 \
     --hash=sha256:20c28ca19079a6c879258103a6d60b94d4ffe2d9da07dda93fb1c8bc6243f522 \

--- a/src/bygg/cmd/apply_configuration.py
+++ b/src/bygg/cmd/apply_configuration.py
@@ -5,11 +5,10 @@ import subprocess
 import sys
 import textwrap
 
-from loguru import logger
-
 from bygg.cmd.configuration import PYTHON_INPUTFILE, ByggFile, Environment
 from bygg.core.action import Action
 from bygg.core.digest import calculate_string_digest
+from bygg.logging import logger
 from bygg.output.output import output_error, output_info, output_plain
 from bygg.util import create_shell_command
 

--- a/src/bygg/cmd/argument_parsing.py
+++ b/src/bygg/cmd/argument_parsing.py
@@ -2,9 +2,9 @@ import argparse
 from typing import Any
 
 from argcomplete.completers import BaseCompleter
-from loguru import logger
 
 from bygg.cmd.completions import ByggfileDirectoriesCompleter
+from bygg.logging import logger
 
 
 def create_argument_parser(entrypoint_completions: BaseCompleter):

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -6,7 +6,6 @@ import sys
 import tempfile
 
 from argcomplete.completers import BaseCompleter
-from loguru import logger
 
 from bygg.cmd.apply_configuration import apply_configuration
 from bygg.cmd.argument_parsing import create_argument_parser
@@ -30,6 +29,7 @@ from bygg.cmd.list_actions import list_actions, list_collect_subprocess, print_a
 from bygg.cmd.tree import display_tree, print_tree
 from bygg.core.runner import ProcessRunner
 from bygg.core.scheduler import Scheduler
+from bygg.logging import logger
 from bygg.output.output import (
     output_error,
     output_info,

--- a/src/bygg/cmd/list_actions.py
+++ b/src/bygg/cmd/list_actions.py
@@ -4,8 +4,6 @@ import shutil
 import sys
 import textwrap
 
-from loguru import logger
-
 from bygg.cmd.configuration import DEFAULT_ENVIRONMENT_NAME
 from bygg.cmd.datastructures import (
     ByggContext,
@@ -14,6 +12,7 @@ from bygg.cmd.datastructures import (
     SubProcessIpcDataList,
     get_entrypoints,
 )
+from bygg.logging import logger
 from bygg.output.output import (
     TerminalStyle as TS,
 )

--- a/src/bygg/core/scheduler.py
+++ b/src/bygg/core/scheduler.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from typing import Literal
 
-from loguru import logger
-
 from bygg.core.action import Action, CommandStatus
 from bygg.core.cache import Cache
 from bygg.core.dag import Dag, create_dag
 from bygg.core.digest import calculate_dependency_digest, calculate_digest
+from bygg.logging import logger
 from bygg.output.status_display import on_check_failed
 
 

--- a/src/bygg/logging.py
+++ b/src/bygg/logging.py
@@ -1,0 +1,93 @@
+import datetime
+import logging
+import os
+
+from bygg.output.output import TerminalStyle as TS
+
+
+def __getattr__(name):
+    if name == "logger":
+        return logging.getLogger("bygg")
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+class CustomLogFormatter(logging.Formatter):
+    COLORS = {
+        "DEBUG": TS.Fg.BLUE,
+        "INFO": TS.Fg.GREEN,
+        "WARNING": TS.Fg.YELLOW,
+        "ERROR": TS.Fg.RED,
+        "CRITICAL": TS.Fg.RED + TS.BOLD,
+    }
+
+    no_colors = False
+
+    def __init__(
+        self,
+        fmt: str | None = None,
+        datefmt: str | None = None,
+        no_colors: bool = False,
+    ):
+        super().__init__(fmt, datefmt)
+        self.no_colors = no_colors
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Doesn't care about the format string used when instantiating the logger
+        level_color = self.COLORS.get(record.levelname, "")
+        filename_width = 40
+        # Add the length of the colour code so the width will be the same for no_colors
+        color_filename_width = filename_width + len(TS.Fg.WHITE)
+
+        filename = (
+            f"{record.filename + ':' + str(record.lineno) :<{filename_width}}"
+            if self.no_colors
+            else f"{TS.Fg.CYAN}{record.filename + ':' + TS.Fg.WHITE + str(record.lineno) :<{color_filename_width}}{TS.RESET}"
+        )
+
+        if self.no_colors:
+            return f"{self.formatTime(record)} | {record.name} | {record.levelname:<8} | {filename} | {record.msg.format(*record.args) if record.args else record.getMessage()}"
+
+        return f"{self.formatTime(record)} | {TS.Fg.MAGENTA}{record.name}{TS.RESET} | {level_color}{record.levelname:<8}{TS.RESET} | {filename} | {record.msg.format(*record.args) if record.args else record.getMessage()}"
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        formatted_time = super().formatTime(record, datefmt)
+        if self.no_colors:
+            return formatted_time
+        return f"{TS.Fg.CYAN}{formatted_time}{TS.RESET}"
+
+
+def setup_logging():
+    debug = str.lower(os.environ.get("DEBUG_BYGG", ""))
+
+    if not debug:
+        logging.getLogger("bygg").disabled = True
+        return
+
+    logger = logging.getLogger("bygg")
+    logger.setLevel(logging.DEBUG)
+
+    if "silent" not in debug:
+        colored_formatter = CustomLogFormatter()
+
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(logging.DEBUG)
+        stream_handler.setFormatter(colored_formatter)
+        logger.addHandler(stream_handler)
+
+    # file or silent enables file debugging
+    if "file" in debug or "silent" in debug:
+        bw_formatter = CustomLogFormatter(no_colors=True)
+
+        iso_datetime = datetime.datetime.now().isoformat(timespec="seconds")
+        file_handler = logging.FileHandler(f"debug_{iso_datetime}.log")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(bw_formatter)
+        logger.addHandler(file_handler)
+
+        # Create symlink to latest log
+        latest_log_link = "debug_latest.log"
+        if os.path.lexists(latest_log_link):
+            os.unlink(latest_log_link)
+        os.symlink(f"debug_{iso_datetime}.log", latest_log_link)
+
+    logger.debug("Debug logging enabled")

--- a/src/bygg/main.py
+++ b/src/bygg/main.py
@@ -4,11 +4,8 @@ A build tool written in Python, where all actions can be written in Python.
 
 # PYTHON_ARGCOMPLETE_OK
 
-import os
-
-from loguru import logger
-
 from bygg.cmd.dispatcher import bygg
+from bygg.logging import logger, setup_logging
 from bygg.output.output import output_warning
 
 
@@ -20,24 +17,6 @@ def main():
     except KeyboardInterrupt:
         output_warning("Interrupted by user. Aborting.")
         return 1
-
-
-def setup_logging():
-    debug = str.lower(os.environ.get("DEBUG_BYGG", ""))
-
-    if not debug:
-        logger.disable("bygg")
-        return
-
-    logger.enable("bygg")
-
-    # file or silent enables file debugging
-    if "file" in debug or "silent" in debug:
-        logger.add("debug_{time}.log")
-
-    # Remove the default handler to silence stderr
-    if "silent" in debug:
-        logger.remove(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The features from loguru were not really needed. Configure the standard library logging module with a custom formatter instead.