### PR TITLE
Support for TOML Byggfiles

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,8 @@
 {
   "recommendations": [
     "charliermarsh.ruff",
+    // Can validate Byggfile.toml against the included schema:
+    "tamasfe.even-better-toml",
     // Can validate Byggfile.yml against the included schema:
     "redhat.vscode-yaml"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
+  "evenBetterToml.schema.associations": {
+    "Byggfile.toml": "file://schemas/Byggfile_yml_schema.json",
+  },
   "yaml.schemas": {
     "schemas/Byggfile_yml_schema.json": "Byggfile.yml"
   },

--- a/README.md
+++ b/README.md
@@ -89,13 +89,17 @@ Bygg will check for the presence of `Byggfile.py` in the current directory. The
 actions above would be built with `bygg build1` and `bygg build2`,
 respectively. See the `examples/` directory for worked examples.
 
-### Settings file
+### Settings files
 
-There is also support for declaring actions in a YAML settings file,
-`Byggfile.yml`. This is intended primarily for configuring static settings like
-which virtual environment to use and their respective entrypoints, but can also
-be used for declaring other (static) actions. See
+There is also support for declaring actions, environments and settings in YAML
+and TOML files called `Byggfile.yml` and `Byggfile.toml`, respectively. This is
+intended primarily for configuring static settings like which virtual
+environment to use and their respective entrypoints, but can also be used for
+declaring static actions. See `examples/taskrunner/Byggfile.toml`,
 `examples/taskrunner/Byggfile.yml` and `examples/environments/Byggfile.yml`.
+
+The evaluation order is TOML -> YAML -> Python. Actions and settings declared
+later will override earlier ones.
 
 ## Shell tab completions
 

--- a/examples/taskrunner/Byggfile.toml
+++ b/examples/taskrunner/Byggfile.toml
@@ -1,0 +1,6 @@
+[[actions]]
+name = "do something from TOML"
+description = "A test action in a TOML file"
+message = "I did something from TOML"
+shell = "touch foo_toml"
+dependencies = ["ls", "do something more"]

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -18,10 +18,9 @@ from bygg.cmd.completions import (
 )
 from bygg.cmd.configuration import (
     DEFAULT_ENVIRONMENT_NAME,
-    PYTHON_INPUTFILE,
-    YAML_INPUTFILE,
     ByggFile,
     dump_schema,
+    has_byggfile,
     read_config_file,
 )
 from bygg.cmd.datastructures import ByggContext, SubProcessIpcData
@@ -100,7 +99,7 @@ def dispatcher(
         output_info(f"Entering directory '{directory_arg}'")
         os.chdir(directory_arg)
 
-    if not os.path.isfile(PYTHON_INPUTFILE) and not os.path.isfile(YAML_INPUTFILE):
+    if not has_byggfile():
         output_error("No build files found.")
         sys.exit(1)
 
@@ -108,7 +107,7 @@ def dispatcher(
     ctx = init_bygg_context(configuration)
 
     if not configuration.environments:
-        if os.path.isfile(PYTHON_INPUTFILE) or os.path.isfile(YAML_INPUTFILE):
+        if has_byggfile():
             # No environments, so just load the Python build file directly.
             apply_configuration(configuration, None, None)
 

--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -115,16 +115,19 @@
 # ---
 # name: test_actions_completions[taskrunner]
   list([
+    'do\\ something\\ from\\ TOML',
     'touch\\ a\\ file',
   ])
 # ---
 # name: test_actions_completions[taskrunner].1
   list([
+    'do\\ something\\ from\\ TOML',
     'touch\\ a\\ file',
   ])
 # ---
 # name: test_actions_completions[taskrunner].2
   list([
+    'do\\ something\\ from\\ TOML',
     'touch\\ a\\ file',
   ])
 # ---

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -327,6 +327,9 @@
   touch a file (default)
       No description
   
+  do something from TOML
+      A test action in a TOML file
+  
   
   '''
 # ---
@@ -455,6 +458,9 @@
   
   touch a file (default)
       No description
+  
+  do something from TOML
+      A test action in a TOML file
   
   
   '''


### PR DESCRIPTION
Add support for TOML Byggfiles. Currently only minimally tested and documented.

Configure TOML schema validation for the VSCode extension "Even Better TOML".

Add "Even Better TOML" to the list of recommended extensions for VSCode.