### PR TITLE
Add maintenance commands

### DIFF
--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -26,6 +26,7 @@ from bygg.cmd.configuration import (
 )
 from bygg.cmd.datastructures import ByggContext, SubProcessIpcData
 from bygg.cmd.list_actions import list_actions, list_collect_subprocess, print_actions
+from bygg.cmd.maintenance import perform_maintenance
 from bygg.cmd.tree import display_tree, print_tree
 from bygg.core.runner import ProcessRunner
 from bygg.core.scheduler import Scheduler
@@ -108,6 +109,11 @@ def dispatcher(
         sys.exit(1)
 
     configuration = read_config_file()
+
+    if args.maintenance_commands and not args.is_restarted_with_env:
+        perform_maintenance(configuration, args.maintenance_commands)
+        sys.exit(0)
+
     ctx = init_bygg_context(configuration)
 
     if not configuration.environments:
@@ -214,7 +220,11 @@ def dispatch_for_toplevel_process(
         exec_list += [restart_with]
         if action:
             exec_list += [action]
-        exec_list += unparse_args(parser, args, drop=["actions"])
+        exec_list += unparse_args(
+            parser,
+            args,
+            drop=["actions", "maintenance_commands"],
+        )
         exec_list += ["--is_restarted_with_env", environment]
         exec_list += ["--ipc_filename", ipc_filename]
 

--- a/src/bygg/cmd/environments.py
+++ b/src/bygg/cmd/environments.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 import sys
 
-from bygg.cmd.configuration import Environment
+from bygg.cmd.configuration import Byggfile, Environment
 from bygg.core.digest import calculate_string_digest
 from bygg.output.output import output_error, output_info, output_plain
 
@@ -58,3 +58,14 @@ def setup_environment(environment: Environment):
         f.write(environment_hash)
 
     return True
+
+
+def remove_environments(configuration: Byggfile) -> list[str]:
+    removed_environments: list[str] = []
+    for name, env in configuration.environments.items():
+        venv_path = Path(env.venv_directory)
+        if venv_path.exists():
+            output_info(f"Removing venv {name} at {venv_path}")
+            shutil.rmtree(venv_path)
+            removed_environments.append(name)
+    return removed_environments

--- a/src/bygg/cmd/maintenance.py
+++ b/src/bygg/cmd/maintenance.py
@@ -1,0 +1,23 @@
+from bygg.cmd.argument_parsing import MaintenanceCommand
+from bygg.cmd.configuration import Byggfile
+from bygg.cmd.environments import remove_environments
+from bygg.core.cache import Cache
+from bygg.logging import logger
+from bygg.output.output import output_info
+
+
+def perform_maintenance(configuration: Byggfile, commands: list[MaintenanceCommand]):
+    logger.debug("Maintenance commands: %s", commands)
+    # Sorting for testability and tidyness
+    unique_cmds = sorted(set(commands))
+
+    while unique_cmds and (cmd := unique_cmds.pop()):
+        match cmd:
+            case "remove_cache":
+                output_info("Removing cache")
+                Cache.reset()
+            case "remove_environments":
+                output_info("Removing environments")
+                remove_environments(configuration)
+            case _:
+                raise ValueError(f"Unknown maintenance command '{cmd}'")

--- a/src/bygg/core/cache.py
+++ b/src/bygg/core/cache.py
@@ -27,6 +27,10 @@ class Cache:
         self.data = CacheState({})
         self.db_file = db_file
 
+    @classmethod
+    def reset(cls):
+        DEFAULT_DB_FILE.unlink(missing_ok=True)
+
     def load(self):
         make_sure_status_dir_exists()
         try:

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -534,6 +534,166 @@
   
   '''
 # ---
+# name: test_reset_remove_cache[checks]
+  '''
+  🛈 Entering directory 'examples/checks'
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_remove_cache[environments]
+  '''
+  🛈 Entering directory 'examples/environments'
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_remove_cache[failing_jobs]
+  '''
+  🛈 Entering directory 'examples/failing_jobs'
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_remove_cache[only_python]
+  '''
+  🛈 Entering directory 'examples/only_python'
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_remove_cache[parametric]
+  '''
+  🛈 Entering directory 'examples/parametric'
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_remove_cache[taskrunner]
+  '''
+  🛈 Entering directory 'examples/taskrunner'
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_remove_cache[trivial]
+  '''
+  🛈 Entering directory 'examples/trivial'
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_remove_environments[checks]
+  '''
+  🛈 Entering directory 'examples/checks'
+  🛈 Removing environments
+  
+  '''
+# ---
+# name: test_reset_remove_environments[environments]
+  '''
+  🛈 Entering directory 'examples/environments'
+  🛈 Removing environments
+  🛈 Removing venv env1 at .venv1
+  🛈 Removing venv env2 at .venv2
+  🛈 Removing venv default at .venv
+  
+  '''
+# ---
+# name: test_reset_remove_environments[failing_jobs]
+  '''
+  🛈 Entering directory 'examples/failing_jobs'
+  🛈 Removing environments
+  
+  '''
+# ---
+# name: test_reset_remove_environments[only_python]
+  '''
+  🛈 Entering directory 'examples/only_python'
+  🛈 Removing environments
+  
+  '''
+# ---
+# name: test_reset_remove_environments[parametric]
+  '''
+  🛈 Entering directory 'examples/parametric'
+  🛈 Removing environments
+  
+  '''
+# ---
+# name: test_reset_remove_environments[taskrunner]
+  '''
+  🛈 Entering directory 'examples/taskrunner'
+  🛈 Removing environments
+  
+  '''
+# ---
+# name: test_reset_remove_environments[trivial]
+  '''
+  🛈 Entering directory 'examples/trivial'
+  🛈 Removing environments
+  
+  '''
+# ---
+# name: test_reset_reset[checks]
+  '''
+  🛈 Entering directory 'examples/checks'
+  🛈 Removing environments
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_reset[environments]
+  '''
+  🛈 Entering directory 'examples/environments'
+  🛈 Removing environments
+  🛈 Removing venv env1 at .venv1
+  🛈 Removing venv env2 at .venv2
+  🛈 Removing venv default at .venv
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_reset[failing_jobs]
+  '''
+  🛈 Entering directory 'examples/failing_jobs'
+  🛈 Removing environments
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_reset[only_python]
+  '''
+  🛈 Entering directory 'examples/only_python'
+  🛈 Removing environments
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_reset[parametric]
+  '''
+  🛈 Entering directory 'examples/parametric'
+  🛈 Removing environments
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_reset[taskrunner]
+  '''
+  🛈 Entering directory 'examples/taskrunner'
+  🛈 Removing environments
+  🛈 Removing cache
+  
+  '''
+# ---
+# name: test_reset_reset[trivial]
+  '''
+  🛈 Entering directory 'examples/trivial'
+  🛈 Removing environments
+  🛈 Removing cache
+  
+  '''
+# ---
 # name: test_tree[checks]
   '''
   


### PR DESCRIPTION
Add --reset, --remove-cache and --remove-environments commands. The reset command removes both cache and environments.

No build actions or other operations will be performed when a maintenance command is given.

Closes #208.