### PR TITLE
get_entrypoints cleanup

### DIFF
--- a/src/bygg/cmd/datastructures.py
+++ b/src/bygg/cmd/datastructures.py
@@ -56,8 +56,4 @@ def get_entrypoints(ctx: ByggContext, args: ByggNamespace) -> list[EntryPoint]:
         EntryPoint(x.name, x.description or NO_DESCRIPTION)
         for x in ctx.scheduler.build_actions.values()
         if x.is_entrypoint
-    ] or [
-        EntryPoint(action_name, x.description or NO_DESCRIPTION)
-        for action_name, x in ctx.configuration.actions.items()
-        if x.is_entrypoint and x.environment == args.is_restarted_with_env
     ]


### PR DESCRIPTION
Remove some unneeded code in get_entrypoints that implemented a fallback to returning actions from the configuration if the scheduler did not have any actions. It is no longer called since actions are now always loaded into the scheduler also from environments.

Followup to #159.