### PR TITLE
Update debug configuration in VSCode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,8 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Python: Bygg examples/trivial",
-      "type": "python",
+      "name": "Python: Bygg debug task",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/.venv/bin/bygg",
       "cwd": "${workspaceFolder}/examples/trivial",


### PR DESCRIPTION
- Use debugpy instead of python since the latter is deprecated.
- Change the configuration name to be more general.