### PR TITLE
Improve help formatting

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -11,11 +11,26 @@ nox.options.stop_on_first_error
 python_versions = ["3.11", "3.12", "3.13"]
 
 
+# Not a test, but utility functionality for updating the help snapshots across all
+# tested Python versions.
+# Run with `nox -s update_help_snapshots`.
+@nox.session(default=False, python=python_versions)
+def update_help_snapshots(session):
+    session.install("-r", "requirements.txt", "-r", "requirements-dev.txt")
+    session.install(".")
+    session.run("pytest", "-m", "help", "--snapshot-update")
+
+
 @nox.session(python=python_versions)
 def tests(session):
     session.install("-r", "requirements.txt", "-r", "requirements-dev.txt")
     session.install(".")
-    session.run("pytest", "-vv")
+    session.run("pytest", "-vv", "-m", "not help")
+    # The help test needs separate snapshots for each Python version, and the snapshot
+    # package for pytest (syrupy) will report the snapshots for the Python version not
+    # running currently as unused. Run the help test with the --snapshot-warn-unused
+    # flag.
+    session.run("pytest", "-vv", "-m", "help", "--snapshot-warn-unused")
 
 
 @nox.session(python=python_versions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ addopts = ["-vv", "--import-mode=importlib", "tests/"]
 markers = [
   "digest: Tests for digest functionality.",
   "scheduler: Tests for the scheduler.",
+  "help: Tests for the help functionality.",
 ]
 
 [tool.ruff]

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -218,6 +218,206 @@
   
   '''
 # ---
+# name: test_help[3.11]
+  '''
+  usage: bygg [-h] [-v] [--clean | -l | --tree] [-C DIRECTORY] [-j [JOBS]] [-B]
+              [--check] [--reset] [--remove-cache] [--remove-environments]
+              [--dump-schema] [--completions]
+              [actions ...]
+  
+  A build tool written in Python, where all actions can be written in Python.
+  
+  Build the default action:
+   bygg
+  
+  Build ACTION:
+   bygg ACTION
+  
+  Clean ACTION:
+   bygg ACTION --clean
+  
+  List available actions:
+   bygg --list
+  
+  POSITIONAL ARGUMENTS:
+    actions               Entrypoint actions to operate on.
+  
+  OPTIONS:
+    -h, --help            show this help message and exit
+    -v, --version         Show version string and exit.
+  
+  Commands that operate on the build setup:
+    --clean               Clean the outputs of the specified actions.
+    -l, --list            List available actions.
+    --tree                Display the dependency tree starting from the specified
+                          action(s).
+  
+  Make-like arguments:
+    -C DIRECTORY, --directory DIRECTORY
+                          Change to the specified directory.
+    -j [JOBS], --jobs [JOBS]
+                          Specify the number of jobs to run simultaneously. None
+                          means to use the number of available cores.
+    -B, --always-make     Always build all actions.
+  
+  Analyse and verify:
+    Arguments in this group will add more analysis to the build process. Actions
+    will be built and the analysis result will be reported.
+  
+    --check               Perform various checks on the action tree. Implies -B
+  
+  Maintenance:
+    These commands operate on Bygg's build state. When given a maintenance
+    command, Bygg will just perform the maintenance and exit; it will neither
+    build anything nor perform any other actions.
+  
+    --reset               Remove the cache and the Python environments. Same as
+                          giving --remove-cache and --remove-environments.
+    --remove-cache        Remove the build cache.
+    --remove-environments
+                          Remove the Python environments.
+  
+  Meta arguments:
+    --dump-schema         Generate a JSON Schema for the Byggfile.yml files. The
+                          schema will be printed to stdout.
+    --completions         Output instructions for how to set up shell completions
+                          via the shell's startup script.
+  
+  '''
+# ---
+# name: test_help[3.12]
+  '''
+  usage: bygg [-h] [-v] [--clean | -l | --tree] [-C DIRECTORY] [-j [JOBS]] [-B]
+              [--check] [--reset] [--remove-cache] [--remove-environments]
+              [--dump-schema] [--completions]
+              [actions ...]
+  
+  A build tool written in Python, where all actions can be written in Python.
+  
+  Build the default action:
+   bygg
+  
+  Build ACTION:
+   bygg ACTION
+  
+  Clean ACTION:
+   bygg ACTION --clean
+  
+  List available actions:
+   bygg --list
+  
+  POSITIONAL ARGUMENTS:
+    actions               Entrypoint actions to operate on.
+  
+  OPTIONS:
+    -h, --help            show this help message and exit
+    -v, --version         Show version string and exit.
+  
+  Commands that operate on the build setup:
+    --clean               Clean the outputs of the specified actions.
+    -l, --list            List available actions.
+    --tree                Display the dependency tree starting from the specified
+                          action(s).
+  
+  Make-like arguments:
+    -C DIRECTORY, --directory DIRECTORY
+                          Change to the specified directory.
+    -j [JOBS], --jobs [JOBS]
+                          Specify the number of jobs to run simultaneously. None
+                          means to use the number of available cores.
+    -B, --always-make     Always build all actions.
+  
+  Analyse and verify:
+    Arguments in this group will add more analysis to the build process. Actions
+    will be built and the analysis result will be reported.
+  
+    --check               Perform various checks on the action tree. Implies -B
+  
+  Maintenance:
+    These commands operate on Bygg's build state. When given a maintenance
+    command, Bygg will just perform the maintenance and exit; it will neither
+    build anything nor perform any other actions.
+  
+    --reset               Remove the cache and the Python environments. Same as
+                          giving --remove-cache and --remove-environments.
+    --remove-cache        Remove the build cache.
+    --remove-environments
+                          Remove the Python environments.
+  
+  Meta arguments:
+    --dump-schema         Generate a JSON Schema for the Byggfile.yml files. The
+                          schema will be printed to stdout.
+    --completions         Output instructions for how to set up shell completions
+                          via the shell's startup script.
+  
+  '''
+# ---
+# name: test_help[3.13]
+  '''
+  usage: bygg [-h] [-v] [--clean | -l | --tree] [-C DIRECTORY] [-j [JOBS]] [-B]
+              [--check] [--reset] [--remove-cache] [--remove-environments]
+              [--dump-schema] [--completions]
+              [actions ...]
+  
+  A build tool written in Python, where all actions can be written in Python.
+  
+  Build the default action:
+   bygg
+  
+  Build ACTION:
+   bygg ACTION
+  
+  Clean ACTION:
+   bygg ACTION --clean
+  
+  List available actions:
+   bygg --list
+  
+  POSITIONAL ARGUMENTS:
+    actions               Entrypoint actions to operate on.
+  
+  OPTIONS:
+    -h, --help            show this help message and exit
+    -v, --version         Show version string and exit.
+  
+  Commands that operate on the build setup:
+    --clean               Clean the outputs of the specified actions.
+    -l, --list            List available actions.
+    --tree                Display the dependency tree starting from the specified
+                          action(s).
+  
+  Make-like arguments:
+    -C, --directory DIRECTORY
+                          Change to the specified directory.
+    -j, --jobs [JOBS]     Specify the number of jobs to run simultaneously. None
+                          means to use the number of available cores.
+    -B, --always-make     Always build all actions.
+  
+  Analyse and verify:
+    Arguments in this group will add more analysis to the build process. Actions
+    will be built and the analysis result will be reported.
+  
+    --check               Perform various checks on the action tree. Implies -B
+  
+  Maintenance:
+    These commands operate on Bygg's build state. When given a maintenance
+    command, Bygg will just perform the maintenance and exit; it will neither
+    build anything nor perform any other actions.
+  
+    --reset               Remove the cache and the Python environments. Same as
+                          giving --remove-cache and --remove-environments.
+    --remove-cache        Remove the build cache.
+    --remove-environments
+                          Remove the Python environments.
+  
+  Meta arguments:
+    --dump-schema         Generate a JSON Schema for the Byggfile.yml files. The
+                          schema will be printed to stdout.
+    --completions         Output instructions for how to set up shell completions
+                          via the shell's startup script.
+  
+  '''
+# ---
 # name: test_list[checks]
   '''
   Available actions:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,10 +2,25 @@ from dataclasses import dataclass, field
 from pathlib import Path
 import re
 import subprocess
+import sys
 
 import pytest
 
 from bygg.core.cache import DEFAULT_DB_FILE
+
+
+@pytest.mark.help
+@pytest.mark.parametrize(
+    "python_version", [f"{sys.version_info.major}.{sys.version_info.minor}"]
+)
+def test_help(snapshot, clean_bygg_tree, python_version):
+    process = subprocess.run(
+        ["bygg", "--help"],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert process.returncode == 0
+    assert process.stdout == snapshot
 
 
 @dataclass


### PR DESCRIPTION
Implementation:

- Format the help output to max 80 columns.
- Change default group titles to all caps.

Testing:

- Add a snapshot test for the help output. The snapshots are
  parameterised per Python version, since the argparse help formatting
  changed between Python 3.12 and 3.13.
- Add pytest mark for the help test.
- Run the help test separately with the flag --snapshot-warn-unused so
  that the snapshots for the other Python versions are not reported as
  errors due to being unused.
- Add nox helper session that updates the help test snapshots for all
  Python versions under test. This session is intended to be run
  manually when the tests need to be updated.