### PR TITLE
Move nox basics session into tests

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         python_version: ${{ fromJson(needs.declare_variables.outputs.python_versions) }}
-        nox_session: [tests, basics, examples]
+        nox_session: [tests, examples]
         os: [ubuntu-24.04, macos-15]
         install_uv: [0, 1]
       fail-fast: false

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,11 +31,6 @@ def tests(session):
     # running currently as unused. Run the help test with the --snapshot-warn-unused
     # flag.
     session.run("pytest", "-vv", "-m", "help", "--snapshot-warn-unused")
-
-
-@nox.session(python=python_versions)
-def basics(session):
-    session.install(".")
     session.run("bygg", success_codes=[1], silent=True)
     session.run("bygg", "--help", silent=True)
 


### PR DESCRIPTION
This reduces the number of jobs that have to be run in CI, and the basics session was very small anyway.