### PR TITLE
Add --snapshot-warn-unused flag to pytest options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ bygg = "bygg.main:main"
 include = ["src/bygg", "tests"]
 
 [tool.pytest.ini_options]
-addopts = ["-vv", "--import-mode=importlib", "tests/"]
+addopts = ["-vv", "--import-mode=importlib", "tests/", "--snapshot-warn-unused"]
 markers = [
   "digest: Tests for digest functionality.",
   "scheduler: Tests for the scheduler.",


### PR DESCRIPTION
Add --snapshot-warn-unused flag to the pytest options also in pyproject.toml. This removes the test error also when running pytest directly and not via nox.

Followup to #229.