### PR TITLE
Add focus marker to pytest setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ markers = [
   "digest: Tests for digest functionality.",
   "scheduler: Tests for the scheduler.",
   "help: Tests for the help functionality.",
+  "focus: Marker for test(s) to focus on currently.",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Useful for focusing on just one or a few tests as needed.