### PR TITLE
Store environment name in each action

### DIFF
--- a/src/bygg/cmd/datastructures.py
+++ b/src/bygg/cmd/datastructures.py
@@ -49,6 +49,9 @@ class ByggContext:
 
 @dataclass
 class EntryPoint:
+    def __repr__(self):
+        return self.name
+
     name: str
     description: str
 
@@ -56,9 +59,9 @@ class EntryPoint:
 NO_DESCRIPTION = "No description"
 
 
-def get_entrypoints(ctx: ByggContext) -> list[EntryPoint]:
+def get_entrypoints(ctx: ByggContext, environment_name: str) -> list[EntryPoint]:
     return [
         EntryPoint(x.name, x.description or NO_DESCRIPTION)
         for x in ctx.scheduler.build_actions.values()
-        if x.is_entrypoint
+        if x.is_entrypoint and x.environment == environment_name
     ]

--- a/src/bygg/cmd/environments.py
+++ b/src/bygg/cmd/environments.py
@@ -112,7 +112,7 @@ def load_environment(ctx: ByggContext, environment_name: str):
         return None
 
     python_build_file = environment.byggfile if environment else PYTHON_INPUTFILE
-    load_python_build_file(python_build_file)
+    load_python_build_file(python_build_file, environment_name)
     return None
 
 
@@ -149,10 +149,11 @@ def register_actions_from_configuration(
             outputs=action.outputs,
             dependencies=action.dependencies,
             command=shell_command,
+            environment=action.environment,
         )
 
 
-def load_python_build_file(build_file: str):
+def load_python_build_file(build_file: str, environment_name: str):
     # modify load path to make the current directory importable
     preamble = """\
         import os
@@ -163,4 +164,16 @@ def load_python_build_file(build_file: str):
 
     if os.path.isfile(build_file):
         with open(build_file, "r") as f:
+            Action._current_environment = environment_name
+            logger.info(
+                "Loading Python file %s for environment %s",
+                build_file,
+                environment_name,
+            )
             exec(textwrap.dedent(preamble) + f.read(), globals())
+            logger.info(
+                "Back from loading Python file %s for environment %s",
+                build_file,
+                environment_name,
+            )
+            Action._current_environment = None

--- a/src/bygg/cmd/list_actions.py
+++ b/src/bygg/cmd/list_actions.py
@@ -18,9 +18,11 @@ list_actions_style = "B"
 HEADER = f"{TS.BOLD}Available actions:{TS.RESET}"
 
 
-def list_collect_for_environment(ctx: ByggContext) -> SubProcessIpcDataList:
+def list_collect_for_environment(
+    ctx: ByggContext, environment_name: str
+) -> SubProcessIpcDataList:
     """Collects the currently loaded entrypoints"""
-    entrypoints = get_entrypoints(ctx)
+    entrypoints = get_entrypoints(ctx, environment_name)
     sorted_actions = sorted(entrypoints, key=lambda x: x.name)
     default_action_name = ctx.configuration.settings.default_action
 

--- a/src/bygg/cmd/tree.py
+++ b/src/bygg/cmd/tree.py
@@ -1,6 +1,6 @@
 import itertools
 
-from bygg.cmd.datastructures import SubProcessIpcDataTree, get_entrypoints
+from bygg.cmd.datastructures import ByggContext, SubProcessIpcDataTree, get_entrypoints
 from bygg.output.output import TerminalStyle as TS
 
 
@@ -51,7 +51,9 @@ def print_tree(ipc_data_tree: SubProcessIpcDataTree, actions: list[str]):
         print("\n" + "\n".join(trees))
 
 
-def tree_collect_for_environment(ctx) -> SubProcessIpcDataTree:
+def tree_collect_for_environment(
+    ctx: ByggContext, environment_name: str
+) -> SubProcessIpcDataTree:
     """Collect the currently loaded entrypoints and render their respective dependency
     trees.
 
@@ -66,7 +68,7 @@ def tree_collect_for_environment(ctx) -> SubProcessIpcDataTree:
         └── no_outputs_A
     """
 
-    entrypoints = get_entrypoints(ctx)
+    entrypoints = get_entrypoints(ctx, environment_name)
 
     indent = 4
     style = TreeStyleUnicode(indent)

--- a/src/bygg/core/action.py
+++ b/src/bygg/core/action.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Optional
 
 from bygg.core.common_types import CommandStatus
+from bygg.logging import logger
 
 if TYPE_CHECKING:
     from bygg.core.scheduler import Scheduler
@@ -62,6 +63,7 @@ class Action(ActionContext):
     """
 
     scheduler: Scheduler | None = None
+    _current_environment: str | None = None
 
     command: Command | None
     dependency_files: set[str]
@@ -78,6 +80,7 @@ class Action(ActionContext):
         command: Command | None = None,
         scheduling_type: SchedulingType = "processpool",
         description: str | None = None,
+        environment: Optional[str] = None,
     ):
         self.name = name
         self.message = message
@@ -96,6 +99,10 @@ class Action(ActionContext):
             if command is not None and command.__doc__ is not None
             else None
         )
+
+        self.environment = environment or Action._current_environment
+        assert self.environment
+        logger.info("Constructing Action for environment %s", self.environment)
 
         self.dependency_files = set()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,9 @@ def scheduler_fixture():
     scheduler = Scheduler()
     cache_file = get_closed_tmpfile()
     scheduler.init_cache(cache_file)
+    Action._current_environment = "scheduler_fixture"
     yield (scheduler, cache_file)
+    Action._current_environment = None
     scheduler.shutdown()
 
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -7,7 +7,9 @@ from bygg.core.scheduler import Scheduler
 @pytest.fixture
 def init_scheduler():
     Scheduler()
+    Action._current_environment = "test_Action"
     yield
+    Action._current_environment = None
     Action.scheduler = None
 
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -9,6 +9,7 @@ from bygg.cmd.completions import EntrypointCompleter
 from bygg.cmd.configuration import Byggfile
 from bygg.cmd.datastructures import ByggContext, SubProcessIpcData
 from bygg.cmd.tree import print_tree, tree_collect_for_environment
+from bygg.core.action import Action
 from bygg.core.runner import ProcessRunner
 from bygg.core.scheduler import Scheduler
 
@@ -43,7 +44,10 @@ def test_tree_single_action(
 ):
     scheduler, _ = scheduler_single_action
     ctx = create_byggcontext(scheduler)
-    print_tree(tree_collect_for_environment(ctx), ["action1"])
+    assert Action._current_environment
+    print_tree(
+        tree_collect_for_environment(ctx, Action._current_environment), ["action1"]
+    )
     stdout, _ = capsys.readouterr()
     assert stdout == snapshot
 
@@ -53,7 +57,10 @@ def test_tree_four_nonbranching_actions(
 ):
     scheduler, _ = scheduler_four_nonbranching_actions
     ctx = create_byggcontext(scheduler)
-    print_tree(tree_collect_for_environment(ctx), ["action1"])
+    assert Action._current_environment
+    print_tree(
+        tree_collect_for_environment(ctx, Action._current_environment), ["action1"]
+    )
     stdout, _ = capsys.readouterr()
     assert stdout == snapshot
 
@@ -63,6 +70,9 @@ def test_tree_branching_actions(
 ):
     scheduler, _ = scheduler_branching_actions
     ctx = create_byggcontext(scheduler)
-    print_tree(tree_collect_for_environment(ctx), ["action1"])
+    assert Action._current_environment
+    print_tree(
+        tree_collect_for_environment(ctx, Action._current_environment), ["action1"]
+    )
     stdout, _ = capsys.readouterr()
     assert stdout == snapshot

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,8 +53,10 @@ def test_filenames_from_pattern(test_case):
 
 
 def test_shell_command():
+    Action._current_environment = "test_shell_command"
     shell_command = create_shell_command("echo 'shell action output'")
 
     status = shell_command(Action("test context", inputs=set(), outputs=set()))
     assert status.rc == 0
     assert status.output == "shell action output\n"
+    Action._current_environment = None


### PR DESCRIPTION
Store the name of the environment it belongs to in each action so that the command line commands will only operate on actions from the correct environment.

Previously, actions belonging to the ambient environment would be listed also under any other environment if that environment was already activated in the shell.

