### PR TITLE
Fix --check

### DIFF
--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -147,11 +147,7 @@ def parent_dispatcher(
     logger.info("Actions to be built: %s", actions_to_build)
 
     only_collect = (
-        not actions_to_build
-        or args.list_actions
-        or args.check
-        or args.tree
-        or is_completing()
+        not actions_to_build or args.list_actions or args.tree or is_completing()
     )
 
     # We have nothing to build, but other things to do

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -176,6 +176,35 @@ def test_build_multiple_actions(snapshot, clean_bygg_tree):
     assert "\n".join(sorted(cleaned_result)) == snapshot
 
 
+def test_check(clean_bygg_tree):
+    process = subprocess.run(
+        [
+            "bygg",
+            "-C",
+            examples_dir / "checks",
+        ],
+        cwd=clean_bygg_tree,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert process.returncode == 0
+
+    process = subprocess.run(
+        [
+            "bygg",
+            "-C",
+            examples_dir / "checks",
+            "--check",
+        ],
+        cwd=clean_bygg_tree,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert process.returncode == 1
+    assert "The following checks reported issues:" in process.stdout
+
+
 @pytest.mark.parametrize("example", examples, ids=lambda x: x.name)
 def test_reset_remove_environments(
     snapshot, clean_bygg_tree, example: ExampleParameters


### PR DESCRIPTION
Giving the --check command would neither build nor check. This was due to mistakenly including check among the commands that should only collect data about the build setup.

Fix this and add a rudimentary test for --check.

The regression was introduced in e2ff1967149741bc5b0f1bf53660ae754c1e80c6.