### PR TITLE
Look for Byggfile.toml when completing -C

### DIFF
--- a/src/bygg/cmd/completions.py
+++ b/src/bygg/cmd/completions.py
@@ -9,6 +9,7 @@ from typing import Any, Generator
 from argcomplete.completers import BaseCompleter, DirectoriesCompleter
 from argcomplete.finders import CompletionFinder
 
+from bygg.cmd.configuration import BYGGFILE_SUFFIXES
 from bygg.output.output import output_plain
 
 
@@ -25,7 +26,7 @@ class ByggfileDirectoriesCompleter(DirectoriesCompleter):
             byggfile_dirs |= {
                 str(b.parent)
                 for b in Path(dir).rglob("Byggfile.*")
-                if b.suffix in {".py", ".yml"}
+                if b.suffix in BYGGFILE_SUFFIXES
             }
         for f in sorted(list(byggfile_dirs)):
             yield f

--- a/src/bygg/cmd/configuration.py
+++ b/src/bygg/cmd/configuration.py
@@ -14,6 +14,8 @@ PYTHON_INPUTFILE = "Byggfile.py"
 TOML_INPUTFILE = "Byggfile.toml"
 YAML_INPUTFILE = "Byggfile.yml"
 
+BYGGFILE_SUFFIXES = (".toml", ".yml", ".py")
+
 DEFAULT_ENVIRONMENT_NAME = "_BYGG_DEFAULT_NULL_ENVIRONMENT"
 
 


### PR DESCRIPTION
A directory containing no other Byggfiles but Byggfile.toml would not be completed with -C/--directory.

Followup to 475868edcb0b479e07395ee14ac2e8b665952d27.