### PR TITLE
Add more Trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Build Tools",
+  "Environment :: Console",
+  "Framework :: Pytest",
+  "Typing :: Typed",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Add the following classifiers to pyproject.toml:

- "Intended Audience :: Developers"
- "Topic :: Software Development :: Build Tools"
- "Environment :: Console"
- "Framework :: Pytest"
- "Typing :: Typed"