### PR TITLE
Force uv to use the Python from the current PATH

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -9,8 +9,15 @@ from src.bygg.system_helpers import call
 venv = Path(".venv")
 
 uv_bin = shutil.which("uv")
-venv_command = "python3 -m venv" if not uv_bin else f"{uv_bin} venv"
-pip_install_command = ".venv/bin/pip install" if not uv_bin else f"{uv_bin} pip install --reinstall"
+venv_command = (
+    "python3 -m venv"
+    if not uv_bin
+    # Leave uv out of options but to use the Python active in the shell:
+    else f"{uv_bin} venv --no-project --no-managed-python"
+)
+pip_install_command = (
+    ".venv/bin/pip install" if not uv_bin else f"{uv_bin} pip install --reinstall"
+)
 
 # Always remove existing venv, to make sure requirements are correctly installed.
 if venv.exists():


### PR DESCRIPTION
When running bootstrap.py, uv would install the lowest version of Python that it could find based on the Python requirements set in pyproject.toml.

Adding --no-project and --no-managed-python leaves uv with no choice but to use the Python that is available in the current PATH. This makes the process compatible with using e.g. mise for managing Python versions.