### PR TITLE
Make byggfile optional in environment declarations

### DIFF
--- a/Byggfile.toml
+++ b/Byggfile.toml
@@ -11,7 +11,6 @@ shell = ".venv/bin/python3 ./mypy.py"
 
 [environments.bygg_development]
 name = "Bygg development environment"
-byggfile = "Byggfile.py"
 inputs = ["requirements-dev.txt", "requirements.txt"]
 venv_directory = ".venv"
 shell = '''

--- a/src/bygg/cmd/configuration.py
+++ b/src/bygg/cmd/configuration.py
@@ -80,8 +80,6 @@ class Environment:
 
     Attributes
     ----------
-    byggfile : str
-        The Python Byggfile that uses this environment.
     inputs : list[str]
         A list of files that are used as input to the environment. Typically pip
         requirements files, but can be any files.
@@ -90,14 +88,18 @@ class Environment:
         Bygg if any of the inputs are modified.
     shell : str
         The shell command for creating the environment.
+    byggfile : str
+        The Python Byggfile that uses this environment. This is the entrypoint for where
+        actions declared in Python are looked up. Optional.
     name : str, optional
-        A human-friendly name for the environment. Used in e.g. help messages, by default None
+        A human-friendly name for the environment. Used in e.g. help messages, by
+        default None
     """
 
-    byggfile: str
     inputs: list[str]
     venv_directory: str
     shell: str
+    byggfile: Optional[str] = None
     name: Optional[str] = None
 
 

--- a/src/bygg/cmd/environments.py
+++ b/src/bygg/cmd/environments.py
@@ -113,7 +113,8 @@ def load_environment(ctx: ByggContext, environment_name: str):
         return None
 
     python_build_file = environment.byggfile if environment else PYTHON_INPUTFILE
-    load_python_build_file(python_build_file, environment_name)
+    if python_build_file:
+        load_python_build_file(python_build_file, environment_name)
     return None
 
 

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -58,7 +58,7 @@
           ]
         },
         "title": "Environment",
-        "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\nbyggfile : str\n    The Python Byggfile that uses this environment.\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by default None"
+        "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nbyggfile : str\n    The Python Byggfile that uses this environment. This is the entrypoint for where\n    actions declared in Python are looked up. Optional.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by\n    default None"
       }
     },
     "$defs": {
@@ -190,9 +190,6 @@
         "type": "object",
         "title": "Environment",
         "properties": {
-          "byggfile": {
-            "type": "string"
-          },
           "inputs": {
             "type": "array",
             "items": {
@@ -204,6 +201,17 @@
           },
           "shell": {
             "type": "string"
+          },
+          "byggfile": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
           },
           "name": {
             "anyOf": [
@@ -218,13 +226,12 @@
           }
         },
         "required": [
-          "byggfile",
           "inputs",
           "venv_directory",
           "shell"
         ],
         "additionalProperties": false,
-        "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\nbyggfile : str\n    The Python Byggfile that uses this environment.\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by default None"
+        "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nbyggfile : str\n    The Python Byggfile that uses this environment. This is the entrypoint for where\n    actions declared in Python are looked up. Optional.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by\n    default None"
       }
     },
     "additionalProperties": false


### PR DESCRIPTION
Set Environment.byggfile to be optional, since there are usecases where it makes sense to have a Python environment managed by Bygg that doesn't have any actions declared in Python. One such example is an environment that installs utilities that are then run via shell commands, either from a Byggfile or directly from the shell.