### PR TITLE
Have build and clean take singular actions

### DIFF
--- a/src/bygg/cmd/build_clean.py
+++ b/src/bygg/cmd/build_clean.py
@@ -12,7 +12,7 @@ from bygg.output.status_display import failed_checks, output_check_results
 
 def build(
     ctx: ByggContext,
-    actions: list[str],
+    action: str,
     job_count: int | None,
     always_make: bool,
     check: bool,
@@ -34,26 +34,23 @@ def build(
     try:
         max_workers = get_job_count_limit() if job_count is None else job_count
 
-        for action in actions:
-            t1 = time.time()
-            output_info(f"Building action '{action}':")
+        t1 = time.time()
+        output_info(f"Building action '{action}':")
 
-            ctx.scheduler.start_run(
-                action,
-                always_make=always_make,
-                check=check,
-            )
-            status = ctx.runner.start(max_workers)
-            ctx.scheduler.shutdown()
+        ctx.scheduler.start_run(
+            action,
+            always_make=always_make,
+            check=check,
+        )
+        status = ctx.runner.start(max_workers)
+        ctx.scheduler.shutdown()
 
-            if status:
-                output_ok(f"Action '{action}' completed in {time.time() - t1:.2f} s.")
-            else:
-                output_error(
-                    f"Action '{action}' failed after {time.time() - t1:.2f} s."
-                )
-                output_job_logs(ctx.runner.failed_jobs)
-                return False
+        if status:
+            output_ok(f"Action '{action}' completed in {time.time() - t1:.2f} s.")
+        else:
+            output_error(f"Action '{action}' failed after {time.time() - t1:.2f} s.")
+            output_job_logs(ctx.runner.failed_jobs)
+            return False
 
     except KeyboardInterrupt:
         output_warning("\nBuild was interrupted by user.")
@@ -70,26 +67,25 @@ def build(
     return True
 
 
-def clean(ctx: ByggContext, actions: list[str]):
+def clean(ctx: ByggContext, action: str):
     try:
-        for action in actions:
-            output_info(f"Cleaning action '{action}':")
-            ctx.scheduler.prepare_run(action)
-            for job_name in ctx.scheduler.job_graph.get_all_jobs():
-                job = ctx.scheduler.build_actions.get(job_name, None)
-                if job is None:
-                    continue
-                for output in job.outputs:
-                    try:
-                        s = os.stat(output)
-                        if stat.S_ISREG(s.st_mode):
-                            os.unlink(output)
-                        elif stat.S_ISDIR(s.st_mode):
-                            output_info(f"Removing directory: {output}")
-                            shutil.rmtree(output)
-                    except FileNotFoundError:
-                        pass
-            ctx.scheduler.shutdown()
+        output_info(f"Cleaning action '{action}':")
+        ctx.scheduler.prepare_run(action)
+        for job_name in ctx.scheduler.job_graph.get_all_jobs():
+            job = ctx.scheduler.build_actions.get(job_name, None)
+            if job is None:
+                continue
+            for output in job.outputs:
+                try:
+                    s = os.stat(output)
+                    if stat.S_ISREG(s.st_mode):
+                        os.unlink(output)
+                    elif stat.S_ISDIR(s.st_mode):
+                        output_info(f"Removing directory: {output}")
+                        shutil.rmtree(output)
+                except FileNotFoundError:
+                    pass
+        ctx.scheduler.shutdown()
     except KeyboardInterrupt:
         output_warning("Build was interrupted by user.")
         return False

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -299,11 +299,11 @@ def run_or_collect_in_environment(
     # Build or clean handled below. These are the only commands handled here.
     status = False
     if ctx.bygg_namespace.clean:
-        status = clean(ctx, [action])
+        status = clean(ctx, action)
     else:
         status = build(
             ctx,
-            [action],
+            action,
             ctx.bygg_namespace.jobs,
             ctx.bygg_namespace.always_make,
             ctx.bygg_namespace.check,
@@ -445,9 +445,9 @@ def subprocess_dispatcher(parser, args_namespace):
         sys.exit(DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE)
 
     if args.clean:
-        status = clean(ctx, [action])
+        status = clean(ctx, action)
     else:
-        status = build(ctx, [action], args.jobs, args.always_make, args.check)
+        status = build(ctx, action, args.jobs, args.always_make, args.check)
 
     if not status:
         sys.exit(1)


### PR DESCRIPTION
The build and clean commands are no longer called with lists of actions to work on, so simplify them to only take an action name instead.