### PR TITLE
Handle failed jobs at dispatcher top level

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -81,7 +81,7 @@ def examples(session):
 
     with session.chdir("examples/checks"):
         session.run("bygg")
-        session.run("bygg", "--check", success_codes=[1])
+        session.run("bygg", "--check")
         session.run("bygg", "--tree")
-        session.run("bygg", "all_checks", "--check", success_codes=[1])
+        session.run("bygg", "all_checks", "--check")
         session.run("bygg", "all_checks", "--tree")

--- a/src/bygg/cmd/datastructures.py
+++ b/src/bygg/cmd/datastructures.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from bygg.cmd.argument_parsing import ByggNamespace
 from bygg.cmd.configuration import Byggfile
+from bygg.core.common_types import CommandStatus
 from bygg.core.runner import ProcessRunner
 from bygg.core.scheduler import Scheduler
 
@@ -33,6 +34,7 @@ class SubProcessIpcData:
     tree: Optional[SubProcessIpcDataTree] = None
     return_code: int = 0
     found_input_files: set[str] = field(default_factory=set)
+    failed_jobs: dict[str, CommandStatus] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -201,7 +201,7 @@ def test_check(clean_bygg_tree):
         capture_output=True,
         encoding="utf-8",
     )
-    assert process.returncode == 1
+    assert process.returncode == 0
     assert "The following checks reported issues:" in process.stdout
 
 


### PR DESCRIPTION
Propagate failed jobs status to the top level of the dispatcher instead of doing sys.exit. This makes --watch work also for failed jobs. Followup to 29cd1c76f9af41e299eec65f052b801c791b2a78.

Also output a status summary of the failed jobs.

This commit changes the status code of --check to be what the relevant build job returned instead of always being 1, and the relevant tests have been changed to reflect that. This is more of a side effect of the current implementation than it is a conscious decision on what --check actually should return.