### PR TITLE
Add succeed and fail test actions to taskrunner example

### DIFF
--- a/examples/taskrunner/Byggfile.toml
+++ b/examples/taskrunner/Byggfile.toml
@@ -7,3 +7,11 @@ dependencies = ["ls", "do something more"]
 [actions]
 shorthand_action_toml = "ls -l"
 "shorthand action toml, with spaces" = "ls -hal"
+
+[actions.succeed]
+shell = "true"
+inputs = ["Byggfile.toml"]
+
+[actions.fail]
+shell = "false"
+inputs = ["Byggfile.toml"]

--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -116,30 +116,36 @@
 # name: test_actions_completions[taskrunner]
   list([
     'do\\ something\\ from\\ TOML',
+    'fail',
     'shorthand\\ action\\ toml,\\ with\\ spaces',
     'shorthand\\ action\\ yaml,\\ with\\ spaces',
     'shorthand_action_toml',
     'shorthand_action_yaml',
+    'succeed',
     'touch\\ a\\ file',
   ])
 # ---
 # name: test_actions_completions[taskrunner].1
   list([
     'do\\ something\\ from\\ TOML',
+    'fail',
     'shorthand\\ action\\ toml,\\ with\\ spaces',
     'shorthand\\ action\\ yaml,\\ with\\ spaces',
     'shorthand_action_toml',
     'shorthand_action_yaml',
+    'succeed',
     'touch\\ a\\ file',
   ])
 # ---
 # name: test_actions_completions[taskrunner].2
   list([
     'do\\ something\\ from\\ TOML',
+    'fail',
     'shorthand\\ action\\ toml,\\ with\\ spaces',
     'shorthand\\ action\\ yaml,\\ with\\ spaces',
     'shorthand_action_toml',
     'shorthand_action_yaml',
+    'succeed',
     'touch\\ a\\ file',
   ])
 # ---

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -554,6 +554,9 @@
   do something from TOML
       A test action in a TOML file
   
+  fail
+      `false`
+  
   shorthand action toml, with spaces
       `ls -hal`
   
@@ -565,6 +568,9 @@
   
   shorthand_action_yaml
       `ls -l`
+  
+  succeed
+      `true`
   
   touch a file (default)
       `touch foo`
@@ -700,6 +706,9 @@
   do something from TOML
       A test action in a TOML file
   
+  fail
+      `false`
+  
   shorthand action toml, with spaces
       `ls -hal`
   
@@ -711,6 +720,9 @@
   
   shorthand_action_yaml
       `ls -l`
+  
+  succeed
+      `true`
   
   touch a file (default)
       `touch foo`


### PR DESCRIPTION
Useful for testing watch functionality and return codes in general.