### PR TITLE
Simplify test_filenames_from_pattern

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ from bygg.util import create_shell_command, filenames_from_pattern
 test_cases_filenames_from_pattern = [
     (
         (
-            ["/foo/bar/baz.txt.j2"],
             "%.j2",
             "out_%",
             [("/foo/bar/baz.txt.j2", "/foo/bar/out_baz.txt")],
@@ -14,7 +13,6 @@ test_cases_filenames_from_pattern = [
     ),
     (
         (
-            ["/foo/bar/baz.txt.j2"],
             "%.txt.j2",
             "out_%.txt",
             [("/foo/bar/baz.txt.j2", "/foo/bar/out_baz.txt")],
@@ -22,7 +20,6 @@ test_cases_filenames_from_pattern = [
     ),
     (
         (
-            ["foo.c", "bar.c"],
             "%.c",
             "%.o",
             [("foo.c", "foo.o"), ("bar.c", "bar.o")],
@@ -30,7 +27,6 @@ test_cases_filenames_from_pattern = [
     ),
     (
         (
-            ["foo.txt", "bar.txt"],
             "%",
             "out_%",
             [("foo.txt", "out_foo.txt"), ("bar.txt", "out_bar.txt")],
@@ -40,16 +36,20 @@ test_cases_filenames_from_pattern = [
 
 
 def construct_test_case_name(x: tuple):
-    a, b, c, d = x
-    return f"{b} | {c}"
+    a, b, c = x
+    return f"{a} | {b}"
 
 
 @pytest.mark.parametrize(
     "test_case", test_cases_filenames_from_pattern, ids=construct_test_case_name
 )
 def test_filenames_from_pattern(test_case):
-    input_files, in_pattern, out_pattern, output_files = test_case
-    assert filenames_from_pattern(input_files, in_pattern, out_pattern) == output_files
+    in_pattern, out_pattern, input_output_files = test_case
+    input_files = [x[0] for x in input_output_files]
+    assert (
+        filenames_from_pattern(input_files, in_pattern, out_pattern)
+        == input_output_files
+    )
 
 
 def test_shell_command():


### PR DESCRIPTION
Extract the input files from the input-output tuples instead of having to declare them in a separate list.