### PR TITLE
Renovate filenames_from_pattern utility function

### DIFF
--- a/src/bygg/util.py
+++ b/src/bygg/util.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import os
 import re
 import subprocess
@@ -21,24 +22,89 @@ def create_shell_command(shell_command: str, message: Optional[str] = None):
     return lambda ctx: call_shell_command(ctx.inputs, ctx.outputs)
 
 
+@dataclass
+class FileListsFromPattern:
+    input_files: list[str]
+    output_files: list[str]
+    unmatched_input_files: list[str]
+
+
 def filenames_from_pattern(
-    input_files: list[str], in_pattern: str, out_pattern: str
-) -> list[tuple[str, str]]:
+    input_files: list[str], in_pattern: str, target_pattern: str
+) -> FileListsFromPattern:
     """
-    Generate a list of tuples with the input and output file names from a a list of
-    input file names and a pattern like in Makefile pattern rules. File names that don't
-    match the pattern are ignored. Example:
+    Generate a list of target filenames from a list of input file names and a pattern
+    like in Makefile pattern rules. File names that don't match the pattern are ignored
+    and returned as a separate list.
+
+    Returns a FileListsFromPattern dataclass containing lists of the input and output
+    filenames as well as the ignored input files.
+
+    Example filename transformation:
 
       ["/foo/bar/baz.txt.j2"], "%.txt.j2", "out_%.txt")
-        => [("/foo/bar/baz.txt.j2", "/foo/bar/out_baz.txt")]
+        => "/foo/bar/out_baz.txt"
+
+    Intended to work like the corresponding mechanism in GNU Makefiles. From
+    https://www.gnu.org/software/make/manual/html_node/Pattern-Match.html:
+
+    "A target pattern is composed of a ‘%’ between a prefix and a suffix, either or both
+    of which may be empty. The pattern matches a file name only if the file name starts
+    with the prefix and ends with the suffix, without overlap. The text between the
+    prefix and the suffix is called the stem. Thus, when the pattern ‘%.o’ matches the
+    file name test.o, the stem is ‘test’. The pattern rule prerequisites are turned into
+    actual file names by substituting the stem for the character ‘%’. Thus, if in the
+    same example one of the prerequisites is written as ‘%.c’, it expands to ‘test.c’.
+
+    When the target pattern does not contain a slash (and it usually does not),
+    directory names in the file names are removed from the file name before it is
+    compared with the target prefix and suffix. After the comparison of the file name to
+    the target pattern, the directory names, along with the slash that ends them, are
+    added on to the prerequisite file names generated from the pattern rule’s
+    prerequisite patterns and the file name. The directories are ignored only for the
+    purpose of finding an implicit rule to use, not in the application of that rule.
+    Thus, ‘e%t’ matches the file name src/eat, with ‘src/a’ as the stem. When
+    prerequisites are turned into file names, the directories from the stem are added at
+    the front, while the rest of the stem is substituted for the ‘%’. The stem ‘src/a’
+    with a prerequisite pattern ‘c%r’ gives the file name src/car."
     """
 
+    matched_input_files = []
     output_files = []
-    matcher = re.compile(in_pattern.replace("%", "(.+)"))
+    unmatched_input_files = []
+    regex = f"^{in_pattern.replace('%', '(.+)')}$"
+    matcher = re.compile(regex)
+
     for input_file in input_files:
-        head, tail = os.path.split(input_file)
-        matches = matcher.match(tail)
-        if matches:
-            output_file = os.path.join(head, out_pattern.replace("%", matches.group(1)))
-            output_files.append((input_file, output_file))
-    return output_files
+        input_file_head, input_file_tail = os.path.split(input_file)
+        target_pattern_head, _ = os.path.split(target_pattern)
+
+        outfilename = ""
+
+        if target_pattern_head:
+            # Target pattern has a directory, so compare them including directories
+            match_object = matcher.match(input_file)
+            if match_object:
+                stem = match_object.group(1)
+                outfilename = target_pattern.replace("%", stem)
+        else:
+            # Target pattern does not have a directory, so strip each filename from the
+            # directory part before comparing
+            match_object = matcher.match(input_file_tail)
+            if match_object:
+                stem = match_object.group(1)
+                outfilename = os.path.join(
+                    input_file_head, target_pattern.replace("%", stem)
+                )
+
+        if outfilename:
+            matched_input_files.append(input_file)
+            output_files.append(outfilename)
+        else:
+            unmatched_input_files.append(input_file)
+
+    return FileListsFromPattern(
+        matched_input_files,
+        output_files,
+        unmatched_input_files,
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,45 @@ test_cases_filenames_from_pattern = [
             [("foo.txt", "out_foo.txt"), ("bar.txt", "out_bar.txt")],
         )
     ),
+    (
+        (
+            "site/%.html.j2",
+            "output/%.html",
+            [
+                ("site/foo.html.j2", "output/foo.html"),
+                ("site/bar.html.j2", "output/bar.html"),
+            ],
+        )
+    ),
+    (
+        "%.c",
+        "%.o",
+        [
+            ("main.c", "main.o"),
+            ("src/util.c", "src/util.o"),
+            ("lib/helpers/string.c", "lib/helpers/string.o"),
+        ],
+    ),
+    (
+        "assets/%.scss",
+        "css/%.css",
+        [
+            ("assets/main.scss", "css/main.css"),
+            ("assets/components/button.scss", "css/components/button.css"),
+        ],
+    ),
+    (
+        "src/%.md",
+        "build/docs/%.html",
+        [
+            ("src/readme.md", "build/docs/readme.html"),
+            (
+                "src/tutorials/getting-started.md",
+                "build/docs/tutorials/getting-started.html",
+            ),
+        ],
+    ),
+    ("e%t", "c%r", [("eat", "car"), ("src/eat", "src/car"), ("east", "casr")]),
 ]
 
 
@@ -46,10 +85,12 @@ def construct_test_case_name(x: tuple):
 def test_filenames_from_pattern(test_case):
     in_pattern, out_pattern, input_output_files = test_case
     input_files = [x[0] for x in input_output_files]
-    assert (
-        filenames_from_pattern(input_files, in_pattern, out_pattern)
-        == input_output_files
-    )
+    output_files = [x[1] for x in input_output_files]
+
+    result = filenames_from_pattern(input_files, in_pattern, out_pattern)
+    assert result.input_files == input_files
+    assert result.output_files == output_files
+    assert not result.unmatched_input_files
 
 
 def test_shell_command():


### PR DESCRIPTION
Reimplement filenames_from_pattern to match the documentation for GNU make: https://www.gnu.org/software/make/manual/html_node/Pattern-Match.html

Also:

- Change the return type to be a dataclass. This makes it clearer to work with.
- Add more testcases.