### PR TITLE
Use dacite for instantiating dataclasses

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Core
 argcomplete==3.6.2
-cattrs==24.1.3
+dacite==1.9.2
 dc-schema==0.0.8
 dill==0.4.0
 multiprocess==0.70.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,9 @@ argcomplete==3.6.2 \
     --hash=sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591 \
     --hash=sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf
     # via -r requirements.in
-attrs==25.3.0 \
-    --hash=sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3 \
-    --hash=sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b
-    # via cattrs
-cattrs==24.1.3 \
-    --hash=sha256:981a6ef05875b5bb0c7fb68885546186d306f10f0f6718fe9b96c226e68821ff \
-    --hash=sha256:adf957dddd26840f27ffbd060a6c4dd3b2192c5b7c2c0525ef1bd8131d8a83f5
+dacite==1.9.2 \
+    --hash=sha256:053f7c3f5128ca2e9aceb66892b1a3c8936d02c686e707bee96e19deef4bc4a0 \
+    --hash=sha256:6ccc3b299727c7aa17582f0021f6ae14d5de47c7227932c47fec4cdfefd26f09
     # via -r requirements.in
 dc-schema==0.0.8 \
     --hash=sha256:89fed792c63b80a91d4fef723f9aefbca83952eb611fbc168ef8381bf62acbb5 \


### PR DESCRIPTION
Replace cattrs/attrs with dacite for instantiating dataclasses from the config files in YAML/TOML.

dacite covers what is needed and is a much smaller dependency.