### PR TITLE
Restrict when the Code quality workflow runs

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,9 +1,10 @@
 name: Code quality
 on:
-  push:
-    branches: ["**"]
   pull_request:
-    branches: ["**"]
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
Run the workflow only on certain PR events and on pushes to master.

Followup to f4776c831a55910817b1036f77601aeeb08a11db.