### PR TITLE
Add verbose mode

### DIFF
--- a/examples/taskrunner/Byggfile.yml
+++ b/examples/taskrunner/Byggfile.yml
@@ -3,6 +3,7 @@ settings:
 
 actions:
   shorthand_action_yaml: "ls -l"
+  hhgttg: "echo Slartibartfast"
 
   "touch a file":
     message: "I touched a file"

--- a/schemas/Byggfile_yml_schema.json
+++ b/schemas/Byggfile_yml_schema.json
@@ -164,6 +164,17 @@
             }
           ],
           "default": null
+        },
+        "verbose": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "additionalProperties": false,

--- a/src/bygg/cmd/argument_parsing.py
+++ b/src/bygg/cmd/argument_parsing.py
@@ -19,6 +19,7 @@ class ByggNamespace:
 
     actions: list[str]
     version: bool
+    verbose: bool
     is_restarted_with_env: str | None
     ipc_filename: list[str] | None
     clean: bool
@@ -98,6 +99,12 @@ List available actions:
 
     parser.add_argument(
         "-V", "--version", action="store_true", help="Show version string and exit."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable more verbose output from some commands.",
     )
 
     parser.add_argument(

--- a/src/bygg/cmd/configuration.py
+++ b/src/bygg/cmd/configuration.py
@@ -31,8 +31,11 @@ class Settings:
         """
         if other.default_action is not None:
             self.default_action = other.default_action
+        if other.verbose is not None:
+            self.verbose = other.verbose
 
     default_action: Optional[str] = None
+    verbose: Optional[bool] = None
 
 
 @dataclasses.dataclass

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -45,7 +45,10 @@ from bygg.core.scheduler import Scheduler
 from bygg.logging import logger
 from bygg.output.output import TerminalStyle as TS
 from bygg.output.output import output_error, output_info, output_warning
-from bygg.output.status_display import on_job_status, on_runner_status
+from bygg.output.status_display import (
+    get_on_job_status,
+    on_runner_status,
+)
 from bygg.system_helpers import change_dir
 
 
@@ -59,7 +62,7 @@ def init_bygg_context(
     runner = ProcessRunner(scheduler)
 
     # Set up status listeners
-    runner.job_status_listener = on_job_status
+    runner.job_status_listener = get_on_job_status(args, configuration)
     runner.runner_status_listener = on_runner_status
 
     return ByggContext(

--- a/src/bygg/output/job_output.py
+++ b/src/bygg/output/job_output.py
@@ -50,9 +50,26 @@ def output_job_logs(jobs: list[Job]):
     )
     for job in jobs:
         if job.status and (log := job.status.output):
-            output_plain(f'{TS.BOLD}--- Start "{ job.name }" ---{TS.RESET}')
+            output_plain(f'{TS.BOLD}--- Start "{job.name}" ---{TS.RESET}')
             output_plain(
                 highlight_log(log, default_highlight_config) if isatty else log
             )
-            output_plain(f'{TS.BOLD}--- End "{ job.name}" ---{TS.RESET}')
+            output_plain(f'{TS.BOLD}--- End "{job.name}" ---{TS.RESET}')
             output_plain("")
+
+
+def format_job_log(job: Job) -> str:
+    log = job.status.output if job.status else None
+    formatted_log = []
+
+    if not log:
+        formatted_log.append(f"{TS.BOLD}No output from job {job.name}.{TS.RESET}")
+        return ""
+    formatted_log.append(f'{TS.BOLD}--- Start "{job.name}" ---{TS.RESET}')
+    formatted_log.append(
+        highlight_log(log, default_highlight_config) if isatty else log
+    )
+    formatted_log.append(f'{TS.BOLD}--- End "{job.name}" ---{TS.RESET}')
+    formatted_log.append("")
+
+    return "\n".join(formatted_log)

--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -117,6 +117,7 @@
   list([
     'do\\ something\\ from\\ TOML',
     'fail',
+    'hhgttg',
     'shorthand\\ action\\ toml,\\ with\\ spaces',
     'shorthand\\ action\\ yaml,\\ with\\ spaces',
     'shorthand_action_toml',
@@ -129,6 +130,7 @@
   list([
     'do\\ something\\ from\\ TOML',
     'fail',
+    'hhgttg',
     'shorthand\\ action\\ toml,\\ with\\ spaces',
     'shorthand\\ action\\ yaml,\\ with\\ spaces',
     'shorthand_action_toml',
@@ -141,6 +143,7 @@
   list([
     'do\\ something\\ from\\ TOML',
     'fail',
+    'hhgttg',
     'shorthand\\ action\\ toml,\\ with\\ spaces',
     'shorthand\\ action\\ yaml,\\ with\\ spaces',
     'shorthand_action_toml',

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -13,6 +13,17 @@
   bygg >>> Entering directory 'examples/taskrunner'
   '''
 # ---
+# name: test_build_verbose
+  '''
+  OK hhgttg
+  --- Start "hhgttg" ---
+  Slartibartfast
+  
+  --- End "hhgttg" ---
+  
+  
+  '''
+# ---
 # name: test_dump_schema
   '''
   {
@@ -181,6 +192,17 @@
               }
             ],
             "default": null
+          },
+          "verbose": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
           }
         },
         "additionalProperties": false,
@@ -241,9 +263,9 @@
 # ---
 # name: test_help[3.11]
   '''
-  usage: bygg [-h] [-V] [--clean | -l | --tree | -w] [-C DIRECTORY] [-j [JOBS]]
-              [-B] [--check] [--reset] [--remove-cache] [--remove-environments]
-              [--dump-schema] [--completions]
+  usage: bygg [-h] [-V] [-v] [--clean | -l | --tree | -w] [-C DIRECTORY]
+              [-j [JOBS]] [-B] [--check] [--reset] [--remove-cache]
+              [--remove-environments] [--dump-schema] [--completions]
               [actions ...]
   
   A build tool written in Python, where all actions can be written in Python.
@@ -266,6 +288,7 @@
   OPTIONS:
     -h, --help            show this help message and exit
     -V, --version         Show version string and exit.
+    -v, --verbose         Enable more verbose output from some commands.
   
   Commands that operate on the build setup:
     --clean               Clean the outputs of the specified actions.
@@ -309,9 +332,9 @@
 # ---
 # name: test_help[3.12]
   '''
-  usage: bygg [-h] [-V] [--clean | -l | --tree | -w] [-C DIRECTORY] [-j [JOBS]]
-              [-B] [--check] [--reset] [--remove-cache] [--remove-environments]
-              [--dump-schema] [--completions]
+  usage: bygg [-h] [-V] [-v] [--clean | -l | --tree | -w] [-C DIRECTORY]
+              [-j [JOBS]] [-B] [--check] [--reset] [--remove-cache]
+              [--remove-environments] [--dump-schema] [--completions]
               [actions ...]
   
   A build tool written in Python, where all actions can be written in Python.
@@ -334,6 +357,7 @@
   OPTIONS:
     -h, --help            show this help message and exit
     -V, --version         Show version string and exit.
+    -v, --verbose         Enable more verbose output from some commands.
   
   Commands that operate on the build setup:
     --clean               Clean the outputs of the specified actions.
@@ -377,9 +401,9 @@
 # ---
 # name: test_help[3.13]
   '''
-  usage: bygg [-h] [-V] [--clean | -l | --tree | -w] [-C DIRECTORY] [-j [JOBS]]
-              [-B] [--check] [--reset] [--remove-cache] [--remove-environments]
-              [--dump-schema] [--completions]
+  usage: bygg [-h] [-V] [-v] [--clean | -l | --tree | -w] [-C DIRECTORY]
+              [-j [JOBS]] [-B] [--check] [--reset] [--remove-cache]
+              [--remove-environments] [--dump-schema] [--completions]
               [actions ...]
   
   A build tool written in Python, where all actions can be written in Python.
@@ -402,6 +426,7 @@
   OPTIONS:
     -h, --help            show this help message and exit
     -V, --version         Show version string and exit.
+    -v, --verbose         Enable more verbose output from some commands.
   
   Commands that operate on the build setup:
     --clean               Clean the outputs of the specified actions.
@@ -557,6 +582,9 @@
   fail
       `false`
   
+  hhgttg
+      `echo Slartibartfast`
+  
   shorthand action toml, with spaces
       `ls -hal`
   
@@ -708,6 +736,9 @@
   
   fail
       `false`
+  
+  hhgttg
+      `echo Slartibartfast`
   
   shorthand action toml, with spaces
       `ls -hal`

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -46,7 +46,8 @@ def completion_tester(monkeypatch, tmp_path):
 
 args = [
     # Complete simple arguments:
-    ("--ver", "--version "),
+    ("--vers", "--version "),
+    ("--verb", "--verbose "),
     ("--cl", "--clean "),
     ("--h", "--help "),
     # No completions after these arguments:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -190,6 +190,26 @@ def test_build_multiple_actions(snapshot, clean_bygg_tree):
     assert "\n".join(sorted(cleaned_result)) == snapshot
 
 
+def test_build_verbose(snapshot, clean_bygg_tree):
+    process = subprocess.run(
+        [
+            "bygg",
+            "-C",
+            examples_dir / "taskrunner",
+            "hhgttg",
+            "--verbose",
+        ],
+        cwd=clean_bygg_tree,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert process.returncode == 0
+    cleaned_result = [
+        line for line in process.stdout.split("\n") if not line.startswith("bygg >>>")
+    ]
+    assert "\n".join(cleaned_result) == snapshot
+
+
 def test_check(clean_bygg_tree):
     process = subprocess.run(
         [


### PR DESCRIPTION
Output the build job logs when in verbose mode. Can be controlled from the command line with the argument -v/--verbose and from the settings section of the settings file using the key "verbose".

- Modify the status output format slightly when in verbose mode.
- Surround the job log with markers.