### PR TITLE
Implement restart functionality

### DIFF
--- a/src/bygg/core/common_types.py
+++ b/src/bygg/core/common_types.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Literal
 
+RunnerInstruction = Literal["restart_build", "exit_job_failed"]
+
 
 @dataclass
 class CommandStatus:
@@ -9,6 +11,7 @@ class CommandStatus:
     rc: int  # return code; follows shell conventions where 0 is success
     message: str | None  # a message to display to the user
     output: str | None  # output of the command
+    runner_instruction: RunnerInstruction | None = None  # instruction to the runner
 
 
 JobStatus = Literal["queued", "running", "finished", "failed", "stopped", "skipped"]

--- a/testcases/restart_build/.gitignore
+++ b/testcases/restart_build/.gitignore
@@ -1,0 +1,1 @@
+restart_status.txt

--- a/testcases/restart_build/Byggfile.py
+++ b/testcases/restart_build/Byggfile.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import time
+
+from bygg.core.action import ActionContext, action
+from bygg.core.common_types import CommandStatus
+
+
+# Simulate e.g. fetching variables from a CI system. Doing it twice is not a practical
+# use case, but works for testing.
+@action(
+    name="restart_once",
+    is_entrypoint=True,
+    outputs=["restart_status.txt"],
+    dynamic_dependency=lambda: str(time.time()),
+)
+def restart_once(ctx: ActionContext):
+    indicator_file = Path("restart_status.txt")
+    if indicator_file.exists():
+        with indicator_file.open("r", encoding="utf-8") as f:
+            content = f.read()
+        if content == "1":
+            with indicator_file.open("w", encoding="utf-8") as f:
+                content = f.write("2")
+            return CommandStatus(0, "Restarting 1", None, "restart_build")
+        if content == "2":
+            return CommandStatus(0, "Proceeding, was up-to-date", None)
+    else:
+        with indicator_file.open("w", encoding="utf-8") as f:
+            content = f.write("1")
+    return CommandStatus(0, "Restarting", None, "restart_build")
+
+
+@action(name="another_action", inputs=["has_run_once.txt"])
+def another_action(ctx: ActionContext):
+    return CommandStatus(0, "Finished", None)

--- a/tests/__snapshots__/test_testcases.ambr
+++ b/tests/__snapshots__/test_testcases.ambr
@@ -41,3 +41,32 @@
     'files/out',
   ])
 # ---
+# name: test_list[restart_build]
+  '''
+  Available actions:
+  
+  restart_once
+      No description
+  
+  
+  '''
+# ---
+# name: test_list[restart_build].1
+  list([
+    '.gitignore',
+    'Byggfile.py',
+  ])
+# ---
+# name: test_list[restart_build].2
+  list([
+    '.gitignore',
+    'Byggfile.py',
+    'restart_status.txt',
+  ])
+# ---
+# name: test_list[restart_build].3
+  list([
+    '.gitignore',
+    'Byggfile.py',
+  ])
+# ---

--- a/tests/test_testcases.py
+++ b/tests/test_testcases.py
@@ -16,6 +16,7 @@ testcases_dir = Path("testcases")
 
 testcases: list[TestcaseParameters] = [
     TestcaseParameters("action_set", ["testfiles_static"]),
+    TestcaseParameters("restart_build", ["restart_once"]),
 ]
 
 


### PR DESCRIPTION
Actions can now return a runner_instruction in their status field instructing the runner to restart the build. This is useful if something was changed that requires the set of input/output files to be recalculated.

Closes #306.