### PR TITLE
Change name of debug environment variable

### DIFF
--- a/src/bygg/logging.py
+++ b/src/bygg/logging.py
@@ -59,7 +59,7 @@ class CustomLogFormatter(logging.Formatter):
 
 
 def setup_logging():
-    debug = str.lower(os.environ.get("DEBUG_BYGG", ""))
+    debug = str.lower(os.environ.get("BYGG_DEBUG", ""))
 
     if not debug:
         logging.getLogger("bygg").disabled = True


### PR DESCRIPTION
Change name of DEBUG_BYGG environment variable to BYGG_DEBUG. If more environment variables are introduced, they can all have the same prefix.