### PR TITLE
Add more directories to clean_bygg_tree_exclusions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,8 @@ def scheduler_branching_actions(scheduler_fixture):
 clean_bygg_tree_exclusions = (
     "__pycache__",
     ".bygg",
+    ".jj",
+    ".mypy_cache",
     ".nox",
     ".venv*",
     "foo",


### PR DESCRIPTION
The .jj and .mypy_cache directories are not needed for running the tests.