### PR TITLE
Remove unneeded __future__ import

### DIFF
--- a/src/bygg/core/action.py
+++ b/src/bygg/core/action.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Optional
 
@@ -62,7 +60,9 @@ class Action(ActionContext):
         provided, else None.
     """
 
-    scheduler: Scheduler | None = None
+    # Set when Scheduler is initialised. Quotes around the type because of circular
+    # import shenanigans.
+    scheduler: "Scheduler | None" = None
     _current_environment: str | None = None
 
     command: Command | None


### PR DESCRIPTION
The __future__ import is not needed from Python 3.10 and up. However, this import masked a circular import problem. Adjust to that and add a comment.