### PR TITLE
Create EntrypointCompleter where it is used

### DIFF
--- a/src/bygg/cmd/argument_parsing.py
+++ b/src/bygg/cmd/argument_parsing.py
@@ -4,9 +4,7 @@ import shutil
 import textwrap
 from typing import Any, Literal, TypeAlias
 
-from argcomplete.completers import BaseCompleter
-
-from bygg.cmd.completions import ByggfileDirectoriesCompleter
+from bygg.cmd.completions import ByggfileDirectoriesCompleter, EntrypointCompleter
 from bygg.logutils import logger
 
 MaintenanceCommand: TypeAlias = Literal["remove_cache", "remove_environments"]
@@ -65,7 +63,7 @@ def fill_help_text(text: str, width: int, indent: str) -> str:
     )
 
 
-def create_argument_parser(entrypoint_completions: BaseCompleter):
+def create_argument_parser():
     logger.info("Creating argument parser")
 
     parser = argparse.ArgumentParser(
@@ -98,7 +96,7 @@ List available actions:
         default=None,
         help="Entrypoint actions to operate on.",
     )
-    arg.completer = entrypoint_completions
+    arg.completer = EntrypointCompleter()
 
     parser.add_argument(
         "-V", "--version", action="store_true", help="Show version string and exit."

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -11,7 +11,6 @@ from typing import Optional, TypeAlias
 from bygg.cmd.argument_parsing import ByggNamespace, create_argument_parser
 from bygg.cmd.argument_unparsing import unparse_args
 from bygg.cmd.completions import (
-    EntrypointCompleter,
     do_completion,
     generate_shell_completions,
     is_completing,
@@ -89,7 +88,7 @@ DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE = 127
 
 def bygg():
     """Entry point for the Bygg command line interface."""
-    parser = create_argument_parser(EntrypointCompleter())
+    parser = create_argument_parser()
     args = parser.parse_args()
     if not args.is_restarted_with_env:
         do_completion(parser)

--- a/tests/test_argument_unparsing.py
+++ b/tests/test_argument_unparsing.py
@@ -1,7 +1,7 @@
 import pytest
 
 from bygg.cmd.argument_unparsing import unparse_args
-from bygg.cmd.dispatcher import EntrypointCompleter, create_argument_parser
+from bygg.cmd.dispatcher import create_argument_parser
 
 args = [
     (["-V"], ["--version"]),
@@ -25,13 +25,13 @@ args = [
 @pytest.mark.parametrize("arg", args, ids=lambda x: " ".join(x[0]))
 def test_unparse_args(arg):
     in_arg, out_arg = arg
-    parser = create_argument_parser(EntrypointCompleter())
+    parser = create_argument_parser()
     parsed_args = parser.parse_args(in_arg)
     assert sorted(unparse_args(parser, parsed_args)) == sorted(out_arg)
 
 
 def test_unparse_args_drop():
-    parser = create_argument_parser(EntrypointCompleter())
+    parser = create_argument_parser()
     parsed_args = parser.parse_args(["-C", "foo/bar", "action1", "-B"])
     assert sorted(unparse_args(parser, parsed_args, drop=["directory"])) == sorted(
         ["action1", "--always-make"]

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from bygg.cmd.completions import ByggCompletionFinder
-from bygg.cmd.dispatcher import EntrypointCompleter, create_argument_parser
+from bygg.cmd.dispatcher import create_argument_parser
 from bygg.system_helpers import change_dir
 
 
@@ -32,7 +32,7 @@ def completion_tester(monkeypatch, tmp_path):
         # to get its knickers in a twist.
         monkeypatch.setattr("os.fdopen", open_raise)
 
-        parser = create_argument_parser(EntrypointCompleter())
+        parser = create_argument_parser()
         completer = ByggCompletionFinder()
 
         with open(outfile, "w", encoding="utf-8"):

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -5,7 +5,6 @@ from typing import Optional
 import pytest
 
 from bygg.cmd.argument_parsing import ByggNamespace, create_argument_parser
-from bygg.cmd.completions import EntrypointCompleter
 from bygg.cmd.configuration import Byggfile
 from bygg.cmd.datastructures import ByggContext, SubProcessIpcData
 from bygg.cmd.tree import print_tree, tree_collect_for_environment
@@ -24,7 +23,7 @@ class ArgparseFixtureData:
 @pytest.fixture
 def create_byggcontext():
     def instantiate_context(scheduler: Scheduler, argv: Optional[list[str]] = None):
-        parser = create_argument_parser(EntrypointCompleter())
+        parser = create_argument_parser()
         args = parser.parse_args(argv or [])
         return ByggContext(
             ProcessRunner(scheduler),


### PR DESCRIPTION
Create EntrypointCompleter directly in create_argument_parser instead of passing it in to the function. This simplifies the code somewhat.