### PR TITLE
Change is_completing to check for not None

### DIFF
--- a/src/bygg/cmd/completions.py
+++ b/src/bygg/cmd/completions.py
@@ -113,7 +113,7 @@ def do_completion(parser: argparse.ArgumentParser):
 
 
 def is_completing():
-    return os.environ.get("_ARGCOMPLETE") == "1"
+    return os.environ.get("_ARGCOMPLETE") is not None
 
 
 def generate_shell_completions(print_and_exit: bool):


### PR DESCRIPTION
The _ARGCOMPLETE environment variable can have other values than "1" when completing, so change to only check if it is set.