### PR TITLE
Move argcomplete entrypoint to the right place

### DIFF
--- a/src/bygg/cmd/completions.py
+++ b/src/bygg/cmd/completions.py
@@ -108,6 +108,9 @@ class ByggCompletionFinder(CompletionFinder):
 
 
 def do_completion(parser: argparse.ArgumentParser):
+    if "--is_restarted_with_env" in sys.argv:
+        return
+
     completer = ByggCompletionFinder()
     completer(parser)
 

--- a/src/bygg/cmd/dispatcher.py
+++ b/src/bygg/cmd/dispatcher.py
@@ -89,10 +89,9 @@ DISPATCHER_ACTION_NOT_FOUND_EXIT_CODE = 127
 def bygg():
     """Entry point for the Bygg command line interface."""
     parser = create_argument_parser()
+    do_completion(parser)
     args = parser.parse_args()
     if not args.is_restarted_with_env:
-        do_completion(parser)
-
         # Build and potentially watch:
         rc = 0
         while True:


### PR DESCRIPTION
Move the argcomplete entrypoint to where the documentation says it should be: after the argparse parser has been constructed, but before the parser has parsed the arguments.

Previously it was called after argparse had parsed the arguments. This would cause some arguments to not be completed correctly; e.g. "--h" would no longer be detected for completion when using the upcoming subprocess completion testing.