### PR TITLE
Run completion tests in individual subprocesses

### DIFF
--- a/tests/__snapshots__/test_completions.ambr
+++ b/tests/__snapshots__/test_completions.ambr
@@ -417,7 +417,9 @@
 # name: test_actions_completions[--directory-trivial-BYGG_DEV_set]
   list([
     'dynamic',
+    'foo',
     'testfile\\ 1',
+    'testfile\\ 2',
     'transform',
   ])
 # ---
@@ -844,7 +846,9 @@
 # name: test_actions_completions[-C-trivial-BYGG_DEV_set]
   list([
     'dynamic',
+    'foo',
     'testfile\\ 1',
+    'testfile\\ 2',
     'transform',
   ])
 # ---
@@ -1271,7 +1275,9 @@
 # name: test_actions_completions[cwd-trivial-BYGG_DEV_set]
   list([
     'dynamic',
+    'foo',
     'testfile\\ 1',
+    'testfile\\ 2',
     'transform',
   ])
 # ---

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -1,9 +1,9 @@
 from pathlib import Path
+import shlex
+import subprocess
 
 import pytest
 
-from bygg.cmd.completions import ByggCompletionFinder
-from bygg.cmd.dispatcher import create_argument_parser
 from bygg.system_helpers import change_dir
 
 
@@ -27,16 +27,15 @@ def completion_tester(monkeypatch, tmp_path):
         monkeypatch.setenv("COMP_LINE", prefixed_testcase)
         monkeypatch.setenv("COMP_POINT", str(len(prefixed_testcase)))
         monkeypatch.setenv("_ARGCOMPLETE_STDOUT_FILENAME", str(outfile))
-        # Patch os.fdopen to raise NotImplementedError; this causes argcomplete to use
-        # stderr for debug output instead of opening file descriptor 9, which causes pytest
-        # to get its knickers in a twist.
-        monkeypatch.setattr("os.fdopen", open_raise)
 
-        parser = create_argument_parser()
-        completer = ByggCompletionFinder()
+        subprocess.run(
+            shlex.split(prefixed_testcase),
+            capture_output=True,
+            encoding="utf-8",
+        )
 
-        with open(outfile, "w", encoding="utf-8"):
-            completer(parser, exit_method=dummy_exit_method)
+        if not outfile.exists():
+            return ""
 
         with open(outfile, "r", encoding="utf-8") as f:
             return f.read()


### PR DESCRIPTION
Change the completion_tester fixture to test argcomplete by starting bygg as a subprocess instead of just calling the completion functions. This way, Python Byggfiles will be imported and run correctly for each test case.

Also add correct snapshots for the completion tests.

Followup to bc5a261d367377e4b87978a7fc06db8846193981.