### PR TITLE
Return a dummy hash for directories

### DIFF
--- a/src/bygg/core/digest.py
+++ b/src/bygg/core/digest.py
@@ -46,6 +46,9 @@ def calculate_file_digest(file: str | Path) -> str | None:
             )
         return file_digest(real_path)
 
+    if os.path.isdir(real_path):
+        return "directory"
+
 
 def calculate_dependency_digest(filenames: set[str] | set[Path]) -> tuple[str, bool]:
     """

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -47,6 +47,21 @@ def test_calculate_file_digest_non_existing(tmp_path):
     assert map(lambda x: x is None, digests2)
 
 
+def test_calculate_directory_digest_existing(tmp_path):
+    directory = tmp_path / "digest_directory"
+    directory.mkdir()
+
+    digest = calculate_file_digest(str(directory))
+    assert digest == "directory"
+
+
+def test_calculate_directory_digest_non_existing(tmp_path):
+    directory = tmp_path / "digest_directory"
+
+    digest = calculate_file_digest(str(directory))
+    assert digest is None
+
+
 def test_calculate_dependency_digest_existing(tmp_path):
     files = set(tmp_path / filename for filename in ["file1", "file2", "file3"])
 


### PR DESCRIPTION
This allows for correct builds when directories are in the inputs and outputs lists.