### PR TITLE
Add dist directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 __pycache__/
 **/action_digests.json
 _version.py
+dist/
 src/bygg/_bygg_completions.sh


### PR DESCRIPTION
Useful for the occasional local packaging test.