### PR TITLE
Force uv to use the Python from the current PATH also from Byggfile.toml

### DIFF
--- a/Byggfile.toml
+++ b/Byggfile.toml
@@ -17,7 +17,8 @@ name = "Bygg development environment"
 inputs = ["requirements-dev.txt", "requirements.txt"]
 venv_directory = ".venv"
 shell = '''
-uv venv
+# Leave uv out of options but to use the Python active in the shell:
+uv venv --no-project --no-managed-python
 uv pip install -r requirements-dev.txt -r requirements.txt
 uv pip install -e .
 '''


### PR DESCRIPTION
Related to 39391f60354ae8544dfb4992cc754402364d6f48.