### PR TITLE
Strip whitespace from action descriptions

### DIFF
--- a/examples/only_python/Byggfile.py
+++ b/examples/only_python/Byggfile.py
@@ -8,7 +8,14 @@ def hello(ctx: ActionContext):
     return CommandStatus(0, "And goodbye.", None)
 
 
-Action("hello", command=hello, is_entrypoint=True)
+Action(
+    "hello",
+    command=hello,
+    is_entrypoint=True,
+    description="""
+    An action that says 'Hello'.
+    """,
+)
 
 
 @action("hi", is_entrypoint=True)

--- a/src/bygg/core/action.py
+++ b/src/bygg/core/action.py
@@ -95,7 +95,7 @@ class Action(ActionContext):
         self.scheduling_type = scheduling_type
 
         self.description = (
-            description
+            description.strip()
             if description is not None
             else command.__doc__
             if command is not None and command.__doc__ is not None


### PR DESCRIPTION
Multiline strings given to the description Action parameter display with extra initial whitespace if they are formatted with an initial linebreak.

Apply strip() to the description strings and add a testcase for it.