### PR TITLE
Action concurrency limits using WorkChannel objects

### DIFF
--- a/src/bygg/__init__.py
+++ b/src/bygg/__init__.py
@@ -1,9 +1,10 @@
-from .core.action import Action, ActionContext, action
+from .core.action import Action, ActionContext, WorkChannel, action
 from .core.common_types import CommandStatus
 
 __all__ = [
     "Action",
     "ActionContext",
     "CommandStatus",
+    "WorkChannel",
     "action",
 ]


### PR DESCRIPTION
WorkChannel is a class that represents a semaphore with a certain concurrency limit. Create an instance with a unique name and a limit, and then assign it to the Action objects whose concurrency should be limited.