### PR TITLE
Schema renovation

### DIFF
--- a/Byggfile.toml
+++ b/Byggfile.toml
@@ -1,3 +1,7 @@
+"$schema" = "file://schemas/Byggfile_schema.json"
+# Could also be e.g.:
+# "$schema" = "https://raw.githubusercontent.com/rikardg/bygg/refs/heads/master/schemas/Byggfile_schema.json"
+
 [settings]
 verbose = true
 

--- a/schemas/Byggfile_schema.json
+++ b/schemas/Byggfile_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-04/schema",
   "type": "object",
   "title": "Schema for the configuration files for Bygg",
   "properties": {
@@ -42,6 +42,10 @@
       },
       "title": "Environment",
       "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nbyggfile : str\n    The Python Byggfile that uses this environment. This is the entrypoint for where\n    actions declared in Python are looked up. Optional.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by\n    default None"
+    },
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for validation"
     }
   },
   "$defs": {

--- a/src/bygg/cmd/configuration.py
+++ b/src/bygg/cmd/configuration.py
@@ -216,6 +216,19 @@ def dump_schema():
     # See https://github.com/Peter554/dc_schema/issues/6 .
     schema["additionalProperties"] = False
 
+    # $schema handling
+
+    # From https://jj-vcs.github.io/jj/latest/config-schema.json:
+    # "`taplo` and the corresponding VS Code plugins only support version draft-04 of
+    # JSON Schema, see
+    # <https://taplo.tamasfe.dev/configuration/developing-schemas.html>. draft-07 is
+    # mostly compatible with it, newer versions may not be."
+    schema["$schema"] = "http://json-schema.org/draft-04/schema"
+    schema["properties"]["$schema"] = {
+        "type": "string",
+        "description": "JSON Schema reference for validation",
+    }
+
     classes_to_properties = {
         "ActionItem": "actions",
         "Environment": "environments",

--- a/tests/__snapshots__/test_main.ambr
+++ b/tests/__snapshots__/test_main.ambr
@@ -27,7 +27,7 @@
 # name: test_dump_schema
   '''
   {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-04/schema",
     "type": "object",
     "title": "Schema for the configuration files for Bygg",
     "properties": {
@@ -70,6 +70,10 @@
         },
         "title": "Environment",
         "description": "A class used to represent a virtual environment that actions can be run in.\n\nAttributes\n----------\ninputs : list[str]\n    A list of files that are used as input to the environment. Typically pip\n    requirements files, but can be any files.\nvenv_directory : str\n    The directory where the virtual environment is located. Will be recreated by\n    Bygg if any of the inputs are modified.\nshell : str\n    The shell command for creating the environment.\nbyggfile : str\n    The Python Byggfile that uses this environment. This is the entrypoint for where\n    actions declared in Python are looked up. Optional.\nname : str, optional\n    A human-friendly name for the environment. Used in e.g. help messages, by\n    default None"
+      },
+      "$schema": {
+        "type": "string",
+        "description": "JSON Schema reference for validation"
       }
     },
     "$defs": {


### PR DESCRIPTION
- Use JSON Schema draft-04 for compatibility with taplo/Even Better TOML VSCode extension (compatibility note found via jj-vcs).
- Add $schema as allowed property in schema.
- Add inline $schema reference to the local schema in root Byggfile.toml.