### PR TITLE
Don't try to load $schema key from TOML file

### DIFF
--- a/src/bygg/cmd/configuration.py
+++ b/src/bygg/cmd/configuration.py
@@ -164,10 +164,13 @@ def read_config_files() -> Byggfile:
                     import tomllib
 
                     with cf.open("rb") as toml_file:
+                        data = tomllib.load(toml_file)
+                        # We don't care about the $schema property
+                        data.pop("$schema", None)
                         byggfile_objects.append(
                             dacite.from_dict(
                                 config=dacite_config,
-                                data=tomllib.load(toml_file),
+                                data=data,
                                 data_class=Byggfile,
                             )
                         )


### PR DESCRIPTION
The key is not declared in the dataclass, so dacite would freak out. Delete the key before passing the dict to dacite.

Followup to #372.