### PR TITLE
Delete pytest files in clean_bygg_tree fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,8 @@ def clean_bygg_tree(tmp_path):
         clean_path,
         ignore=shutil.ignore_patterns(*clean_bygg_tree_exclusions),
     )
-    return clean_path
+    yield clean_path
+    shutil.rmtree(clean_path)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Use yield instead of returning the created clean tree, and delete the tree before returning from the fixture. This spreads the cleanup time over several processes if running tests in parallel.