### PR TITLE
Reduce copying of files for pytest

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -74,7 +74,7 @@ jobs:
           pyright examples/
       - name: Type check with mypy
         run: |
-          .venv/bin/pip install -e .
+          SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0.dev0 .venv/bin/pip install -e .
           .venv/bin/python3 mypy.py
 
   audit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ markers = [
   "focus: Marker for test(s) to focus on currently.",
 ]
 
+[tool.pytest_env]
+SETUPTOOLS_SCM_PRETEND_VERSION = "0.0.0.dev0"
+
 [tool.ruff]
 exclude = ["_version.py"]
 
@@ -79,6 +82,7 @@ dev = [
   "pyinstrument>=5.0.3",
   "pyright>=1.1.402",
   "pytest>=8.4.1",
+  "pytest-env>=1.2.0",
   "pytest-mock>=3.14.1",
   "pytest-xdist>=3.8.0",
   "ruff>=0.12.2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -176,9 +176,14 @@ pytest==8.4.2 \
     --hash=sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79
     # via
     #   bygg (pyproject.toml:dev)
+    #   pytest-env
     #   pytest-mock
     #   pytest-xdist
     #   syrupy
+pytest-env==1.2.0 \
+    --hash=sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80 \
+    --hash=sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00
+    # via bygg (pyproject.toml:dev)
 pytest-mock==3.15.1 \
     --hash=sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d \
     --hash=sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,7 @@ def scheduler_branching_actions(scheduler_fixture):
 clean_bygg_tree_exclusions = (
     "__pycache__",
     ".bygg",
+    ".git",
     ".jj",
     ".mypy_cache",
     ".nox",


### PR DESCRIPTION
Add the pytest-env plugin and set SETUPTOOLS_SCM_PRETEND_VERSION when running pytest. This avoids hatch-vcs having to have a .git directory in the clean bygg trees used in the pytest tests, which reduces the number of files being copied.