### PR TITLE
Upgrade pip -> 25.3 to resolve CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ force-sort-within-sections = true
 [dependency-groups]
 dev = [
   "mypy>=1.16.1",
-  "pip>=25.2",
+  "pip>=25.3",
   "pyinstrument>=5.0.3",
   "pyright>=1.1.402",
   "pytest>=8.4.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -88,9 +88,9 @@ pathspec==0.12.1 \
     --hash=sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08 \
     --hash=sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712
     # via mypy
-pip==25.2 \
-    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
-    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
+pip==25.3 \
+    --hash=sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
+    --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
     # via bygg (pyproject.toml:dev)
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \


### PR DESCRIPTION
This solves CVE-2025-8869.

See https://github.com/advisories/GHSA-4xh5-x5gv-qwph.